### PR TITLE
11239 Inline Component

### DIFF
--- a/src/components/Inline/Inline.md
+++ b/src/components/Inline/Inline.md
@@ -1,0 +1,9 @@
+A modified `Paragraph` component that renders as an inline `span` element using its inherited styles.
+
+```jsx
+import { Paragraph as P, Inline } from '@moneypensionservice/directories';
+
+<>
+  <P><Inline strike>Amet consectetur adipiscing elit pellentesque habitant morbi tristique</Inline>. Tellus integer feugiat scelerisque varius morbi enim. Commodo odio aenean sed adipiscing diam donec. Sed id semper risus in hendrerit gravida. <Inline weight='700'>Volutpat odio facilisis mauris sit. Tristique senectus et netus et malesuada fames ac turpis.</Inline>  Ac ut consequat semper viverra nam libero. Eu facilisis sed odio morbi quis commodo odio aenean. <Inline color='salmon'>Eu feugiat pretium nibh ipsum consequat nisl vel.</Inline> Semper quis lectus nulla at volutpat diam. Posuere ac ut consequat semper viverra nam. Suscipit adipiscing bibendum est ultricies integer quis. <Inline underline>Ullamcorper velit sed ullamcorper morbi tincidunt ornare. Sit amet purus gravida quis blandit turpis.</Inline>  Bibendum enim facilisis gravida neque convallis a cras semper.</P>
+</>
+```

--- a/src/components/Inline/index.js
+++ b/src/components/Inline/index.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
+import { StyledParagraph } from '../Paragraph/StyledParagraph'
+
+const Inline = ({ a11yTitle, as, color, weight, width, ...rest }) => {
+  return (
+    <StyledParagraph
+      aria-label={a11yTitle}
+      as={as}
+      colorProp={color}
+      weightProp={weight}
+      widthProp={width}
+      {...rest}
+    />
+  )
+}
+
+// Documentation
+Inline.propTypes = {
+  /** The DOM tag or react component to use for the element. */
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
+  /** Content inside component. */
+  children: PropTypes.node,
+  /** Changes the text color. */
+  color: PropTypes.string,
+  /** Set text style to italic. */
+  italic: PropTypes.bool,
+  /** Sets the line-height property. */
+  lineHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  /** Sets the horizontal alignment. Values: start, end, left, right, center, justify, justify-all, or match-parent. */
+  textAlign: PropTypes.oneOfType([
+    PropTypes.oneOf([
+      'start',
+      'end',
+      'left',
+      'right',
+      'center',
+      'justify',
+      'justify-all',
+      'match-parent',
+    ]),
+    PropTypes.object,
+  ]),
+  /** Strike through the text. */
+  strike: PropTypes.bool,
+  /** Sets the font-size property. */
+  textSize: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  /** Underlines the text. */
+  underline: PropTypes.bool,
+  /** Sets the font-weight property. */
+  weight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Sets custom width to the element. */
+  width: PropTypes.string,
+  ...genericPropTypes,
+}
+
+Inline.defaultProps = {
+  as: 'span',
+  color: null,
+  children: null,
+  italic: false,
+  lineHeight: null,
+  strike: false,
+  textAlign: null,
+  textSize: null,
+  underline: false,
+  weight: null,
+  width: '100%',
+  ...genericPropsDefaults(),
+}
+
+/** @component */
+export { Inline }

--- a/src/components/Paragraph/index.js
+++ b/src/components/Paragraph/index.js
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types'
 import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
 import { StyledParagraph } from './StyledParagraph'
 
-const Paragraph = ({ a11yTitle, color, weight, width, ...rest }) => {
+const Paragraph = ({ a11yTitle, as, color, weight, width, ...rest }) => {
   return (
     <StyledParagraph
       aria-label={a11yTitle}
+      as={as}
       colorProp={color}
       weightProp={weight}
       widthProp={width}
@@ -46,7 +47,7 @@ Paragraph.propTypes = {
   /** Underlines the text. */
   underline: PropTypes.bool,
   /** Sets the font-weight property. */
-  weight: PropTypes.number,
+  weight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Sets custom width to the element. */
   width: PropTypes.string,
   ...genericPropTypes,

--- a/src/index.js
+++ b/src/index.js
@@ -7,5 +7,6 @@ export { default as Button } from './components/Button'
 // typography
 export { Heading } from './components/Heading'
 export { Paragraph } from './components/Paragraph'
+export { Inline } from './components/Inline'
 // grid
 export { Container, Row, Col } from './components/Grid'

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -70,6 +70,7 @@ module.exports = {
           components: () => [
             './src/components/Heading/index.js',
             './src/components/Paragraph/index.js',
+            './src/components/Inline/index.js',
           ],
         },
       ],


### PR DESCRIPTION
[TP11239](https://maps.tpondemand.com/entity/11239-inline-component)

This PR aims to implement a new component for inline text. Essentially this new component utilises the previously developed `StyledParagraph.js` and renders it as a span. 
To make this possible, a new `prop` was needed for the `Paragraph` component to render it as a different HTML element.