### PR TITLE
11251 - Formfield Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
-# React component library for Directories project
-![Travis (.org)](https://img.shields.io/travis/moneyadviceservice/react_library)
+# MaPS - Directories React Component Library
+[![Build Status](https://img.shields.io/travis/moneyadviceservice/react_library?branch=master)](https://travis-ci.org/github/moneyadviceservice/react_library)
+[![npm version](https://badge.fury.io/js/%40moneypensionservice%2Fdirectories.svg)](https://badge.fury.io/js/%40moneypensionservice%2Fdirectories)
+[![style: styled-components](https://img.shields.io/badge/style-%F0%9F%92%85%20styled--components-orange.svg?colorB=daa357&colorA=db748e)](https://github.com/styled-components/styled-components)
+[![](https://img.shields.io/badge/Website-Money%20Pensions%20Service-green)](https://www.moneyadviceservice.org.uk/)
 
-## Installing the library on a project
-You can install the component library on another react project using either of the methods given below.
-
-For NPM users:
+## Installation
+The component library is available via NPM or Yarn:
 ```shell
   $ npm install @moneypensionservice/directories
-```
-For Yarn users:
-
-```shell
+  # or
   $ yarn add @moneypensionservice/directories
 ```
 
-## Documentation
-Visit the [documentation website](https://moneyadviceservice.github.io/react_library/) for more information.
+## Usage
+You can find a list of all available components on the [documentation website](https://moneyadviceservice.github.io/react_library/) as well as guides to set up the library on your React application.
 
-## List of the technologies used in this library:
+## Technologies used
 
 - [React](https://reactjs.org/) for creating components and [styled-components](https://www.styled-components.com/) for styling;
 - [Styleguidist](https://react-styleguidist.js.org/) for both live development and generating documentation;
@@ -48,14 +46,15 @@ Cleanup and rebuild the files in the `lib` directory:
 ```shell
   $ npm run prepublishOnly
 ```
-Display the contents of the package that will be published to NPM. Make sure the project builds before publishing:
+
+Make sure the project builds before publishing and display the contents of the package that will be published to NPM:
 ```shell
   $ npm run postbuild
 ```
 
-## Publish the package to NPM
+## Publishing package to NPM
 
-If your user is a member of the NPM registry, login:
+If your user is a member of the [NPM registry](https://www.npmjs.com/org/moneypensionservice), login:
 ```shell
   $ npm login --scope=@moneypensionservice
 ```
@@ -65,7 +64,7 @@ Now you should be ready to publish the package:
   $ npm publish --access=public
 ```
 
-### Adding new users to the NPM Registry
+### Adding new users to the [NPM Registry](https://www.npmjs.com/org/moneypensionservice)
 
 Create an account at [npmjs.com](https://www.npmjs.com/signup). You should ask for an invitation to join the organisation registry.
 
@@ -73,6 +72,7 @@ An admin can add a new member to the registry:
 ```shell
   $ npm adduser --scope=@moneypensionservice
 ```
+or via [npmjs.com](npmjs.com) following [this guide](https://docs.npmjs.com/adding-members-to-your-org).
 
 ## Deploying the [documentation](https://moneyadviceservice.github.io/react_library/)
 Documentation will automatically updated via TravisCI when changes are made to the master branch if the build is successfull. It is available online as a GitHub Page at [https://moneyadviceservice.github.io/react_library/](https://moneyadviceservice.github.io/react_library/).

--- a/src/components/Form/Form.md
+++ b/src/components/Form/Form.md
@@ -1,10 +1,10 @@
-A modified Column component that renders a Form element. All props enabled by the Column component can be used here as well.
-This component also sets some default styles used by its children elements.
+A modified Column component that renders a `form` element. All props enabled by the Column component can be used here as well. <br />
+This component also sets some default styles used by its children elements such as `input`.
 
 ```jsx
 import { Form } from '@moneypensionservice/directories';
 
-<Form margin="6px">
+<Form>
   <fieldset>
     <label>
       Select Me

--- a/src/components/Form/StyledForm.js
+++ b/src/components/Form/StyledForm.js
@@ -11,6 +11,11 @@ const inputFocusOutline = css`
 `
 
 const StyledForm = styled(Col)`
+  ${props => !props.margin && `margin: 0;`}
+  ${props =>
+    !props.padding &&
+    `padding: 0;`}
+    
   input[type='text'],
   input[type='number'],
   input[type='email'],

--- a/src/components/Formfield/Formfield.md
+++ b/src/components/Formfield/Formfield.md
@@ -1,0 +1,21 @@
+A modified Column component that renders a Form element. All props enabled by the Column component can be used here as well.
+This component also sets some default styles used by its children elements.
+
+```jsx
+import { Form, Formfield } from '@moneypensionservice/directories';
+
+<Form margin="6px">
+  <Formfield>
+    <legend>Choose your favorite monster</legend>
+
+    <input type="radio" id="kraken" name="monster" />
+    <label htmlFor="kraken">Kraken</label><br/>
+
+    <input type="radio" id="sasquatch" name="monster" />
+    <label htmlFor="sasquatch">Sasquatch</label><br/>
+
+    <input type="radio" id="mothman" name="monster" />
+    <label htmlFor="mothman">Mothman</label>
+  </Formfield>
+</Form>
+```

--- a/src/components/Formfield/Formfield.md
+++ b/src/components/Formfield/Formfield.md
@@ -1,13 +1,12 @@
-A modified Column component that renders a Form element. All props enabled by the Column component can be used here as well.
-This component also sets some default styles used by its children elements.
+Does your form contain multiple sections of related inputs? Use `Formfield` to generate a `fieldset` element to group them, and the `legend` prop to provide a label for what this section is for.
 
 ```jsx
 import { Form, Formfield } from '@moneypensionservice/directories';
 
-<Form margin="6px">
-  <Formfield>
-    <legend>Choose your favorite monster</legend>
-
+<Form>
+  <Formfield 
+    legend="Choose your favorite monster:"
+    margin={{bottom: "1rem"}} >
     <input type="radio" id="kraken" name="monster" />
     <label htmlFor="kraken">Kraken</label><br/>
 
@@ -16,6 +15,16 @@ import { Form, Formfield } from '@moneypensionservice/directories';
 
     <input type="radio" id="mothman" name="monster" />
     <label htmlFor="mothman">Mothman</label>
+  </Formfield>
+  <Formfield legend="Choose your favorite food:">
+    <input type="radio" id="pizza" name="food" />
+    <label htmlFor="kraken">Pizza</label><br/>
+
+    <input type="radio" id="burger" name="food" />
+    <label htmlFor="sasquatch">Burger</label><br/>
+
+    <input type="radio" id="steak" name="food" />
+    <label htmlFor="mothman">Steak</label>
   </Formfield>
 </Form>
 ```

--- a/src/components/Formfield/StyledFormfield.js
+++ b/src/components/Formfield/StyledFormfield.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+import { resolveMedia, genericStyles } from '../../utils/helpers'
+
+const StyledFormfield = styled.fieldset`
+  ${genericStyles}
+`
+
+export { StyledFormfield }

--- a/src/components/Formfield/StyledFormfield.js
+++ b/src/components/Formfield/StyledFormfield.js
@@ -1,8 +1,18 @@
 import styled from 'styled-components'
-import { resolveMedia, genericStyles } from '../../utils/helpers'
+import { genericStyles } from '../../utils/helpers'
 
 const StyledFormfield = styled.fieldset`
   ${genericStyles}
+  ${props => !props.padding && `padding: 0 1.125rem;`}
 `
 
-export { StyledFormfield }
+const Legend = styled.legend`
+  font-size: 1.125rem;
+  line-height: 1.5rem;
+  font-weight: 700;
+  color: ${props => props.theme.colors.formfield.legendText};
+  width: 100%;
+  margin-bottom: 0.75rem;
+`
+
+export { StyledFormfield, Legend }

--- a/src/components/Formfield/index.js
+++ b/src/components/Formfield/index.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
+import { StyledFormfield } from './StyledFormfield'
+
+const Formfield = ({ a11yTitle, children, ...rest }) => {
+  return (
+    <StyledFormfield aria-label={a11yTitle} {...rest}>
+      {children}
+    </StyledFormfield>
+  )
+}
+
+// Documentation
+Formfield.propTypes = {
+  /** Content inside component. */
+  children: PropTypes.node,
+  ...genericPropTypes,
+}
+
+Formfield.defaultProps = {
+  ...genericPropsDefaults(),
+}
+
+/** @component */
+export { Formfield }

--- a/src/components/Formfield/index.js
+++ b/src/components/Formfield/index.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
-import { StyledFormfield } from './StyledFormfield'
+import { StyledFormfield, Legend } from './StyledFormfield'
 
-const Formfield = ({ a11yTitle, children, ...rest }) => {
+const Formfield = ({ a11yTitle, children, legend, ...rest }) => {
   return (
     <StyledFormfield aria-label={a11yTitle} {...rest}>
+      {legend && <Legend>{legend}</Legend>}
       {children}
     </StyledFormfield>
   )
@@ -15,6 +16,8 @@ const Formfield = ({ a11yTitle, children, ...rest }) => {
 Formfield.propTypes = {
   /** Content inside component. */
   children: PropTypes.node,
+  /** Creates a legend element that represents a caption for the content. */
+  legend: PropTypes.string,
   ...genericPropTypes,
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export { resolveMedia } from './utils/helpers'
 export { default as Button } from './components/Button'
 // input
 export { Form } from './components/Form'
+export { Formfield } from './components/Formfield'
 //Layout
 export { Footer } from './components/Footer'
 export { Header } from './components/Header'

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -49,6 +49,9 @@ export default function() {
       inputBorder: '#515151',
       inputFocus: '#e8b940',
     },
+    formfield: {
+      legendText: '#2e3030',
+    },
     header: {
       background: '#428513',
     },

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -73,7 +73,10 @@ module.exports = {
         },
         {
           name: 'Input',
-          components: () => ['./src/components/Form/index.js'],
+          components: () => [
+            './src/components/Form/index.js',
+            './src/components/Formfield/index.js',
+          ],
         },
         {
           name: 'Layout',


### PR DESCRIPTION
[TP11251](https://maps.tpondemand.com/entity/11251-fieldset-component)

This PR aims to implement the `Formfield` component that will render a `fieldset` element used to group controls inside a form. 

The styles applied to this component come from Yeast.

This component also has a prop to render a `legend` element to provide a caption for the group.

The `Form` component's documentation was also updated and the props for `margin` and `padding` adjusted.