### PR TITLE
11074 - Tooltip Component

### DIFF
--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -1,9 +1,5 @@
 import styled, { css } from 'styled-components'
-import {
-  resolveMedia,
-  genericStyles,
-  responsiveProps,
-} from '../../utils/helpers'
+import { genericStyles, responsiveProps } from '../../utils/helpers'
 import { Anchor } from '../Anchor'
 
 const StyledTooltip = styled.span`
@@ -14,6 +10,8 @@ const StyledTooltip = styled.span`
 /** Side styles for popup */
 const topStyle = css`
   &:after {
+    top: auto;
+    right: auto;
     left: 50%;
     bottom: calc(100% + 5px);
     transform: translate(-50%, -0.5em);
@@ -21,6 +19,7 @@ const topStyle = css`
 `
 const rightStyle = css`
   &:after {
+    bottom: auto;
     top: 50%;
     left: calc(100% + 5px);
     right: calc(0em - 5px);
@@ -29,6 +28,8 @@ const rightStyle = css`
 `
 const bottomStyle = css`
   &:after {
+    right: auto;
+    bottom: auto;
     left: 50%;
     top: calc(100% + 5px);
     transform: translate(-50%, 0.5em);
@@ -36,23 +37,37 @@ const bottomStyle = css`
 `
 const leftStyle = css`
   &:after {
+    bottom: auto;
+    left: auto;
     top: 50%;
     right: calc(100% + 5px);
-    left: calc(0em - 5px);
     transform: translate(-0.5em, -50%);
   }
 `
 
 const sideStyles = {
-  top: topStyle,
-  right: rightStyle,
-  bottom: bottomStyle,
-  left: leftStyle,
+  top: topStyle[0],
+  right: rightStyle[0],
+  bottom: bottomStyle[0],
+  left: leftStyle[0],
+}
+
+const renderSide = sideProp => {
+  // string
+  if (typeof sideProp === 'string') return sideStyles[sideProp]
+  // responsive
+  if (typeof sideProp === 'object') {
+    const responsiveStyles = {}
+    for (let [key, value] of Object.entries(sideProp)) {
+      responsiveStyles[key] = sideStyles[value]
+    }
+    return responsiveProps(null, responsiveStyles)
+  }
 }
 
 const Tip = styled.span`
   /** Prop-based side styles */
-  ${({ side }) => sideStyles[side]}
+  ${({ side }) => renderSide(side)}
   /** Popup */
   &:after {
     ${genericStyles}

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -11,12 +11,6 @@ const StyledTooltip = styled.span`
   cursor: pointer;
 `
 
-const Icon = styled(Anchor)`
-  font-style: italic;
-  color: #428513;
-  padding: 0.375rem;
-`
-
 /** Side styles for popup */
 const topStyle = css`
   &:after {
@@ -63,10 +57,10 @@ const Tip = styled.span`
   &:after {
     ${genericStyles}
     display: ${({ show }) => (show ? 'block' : 'none')};
+    ${({ minWidth }) => responsiveProps('min-width', minWidth)}
     position: absolute;
     z-index: 1000;
     background-color: #FFF;
-    min-width: 160px;
     white-space: pre-wrap;
     padding: 4px 6px;
     border: 1px solid black;
@@ -75,6 +69,12 @@ const Tip = styled.span`
     /** Popup Content */
     content: "${({ text }) => text}";
   }
+`
+
+const Icon = styled(Anchor)`
+  font-style: italic;
+  color: #428513;
+  padding: 0.375rem;
 `
 
 export { StyledTooltip, Icon, Tip }

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -75,14 +75,17 @@ const Tip = styled.span`
     ${({ minWidth }) => responsiveProps('min-width', minWidth)}
     position: absolute;
     z-index: 1000;
-    background-color: #FFF;
-    white-space: pre-wrap;
-    padding: 4px 6px;
+    padding: 8px;
     border: 1px solid black;
     border-radius: 4px;
     box-shadow: 0 1em 2em -0.5em rgba(0, 0, 0, 0.35);
     /** Popup Content */
     content: "${({ text }) => text}";
+    /** text */
+    font-size: 0.875rem;
+    line-height: 1rem;
+    white-space: pre-wrap;
+    background-color: #FFF;
   }
 `
 

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -1,0 +1,30 @@
+import styled, { css } from 'styled-components'
+import { Anchor } from '../Anchor'
+
+const StyledTooltip = styled.div`
+  display: inline-block;
+  position: relative;
+  cursor: pointer;
+  white-space: nowrap;
+`
+
+const Icon = styled(Anchor)`
+  font-style: italic;
+  color: #428513;
+  padding: 0.375rem;
+`
+
+const Tip = styled.div`
+  display: ${({ show }) => (show ? 'block' : 'none')};
+  position: absolute;
+  left: 0;
+  bottom: 20px;
+  z-index: 100;
+  min-width: 300px;
+  white-space: break-spaces;
+  background-color: white;
+  border: 1px solid black;
+  padding: 4px;
+`
+
+export { StyledTooltip, Icon, Tip }

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -17,15 +17,16 @@ const Icon = styled(Anchor)`
   padding: 0.375rem;
 `
 
+/** Side styles for popup */
 const topStyle = css`
-  &:before {
+  &:after {
     left: 50%;
     bottom: calc(100% + 5px);
     transform: translate(-50%, -0.5em);
   }
 `
 const rightStyle = css`
-  &:before {
+  &:after {
     top: 50%;
     left: calc(100% + 5px);
     right: calc(0em - 5px);
@@ -33,14 +34,14 @@ const rightStyle = css`
   }
 `
 const bottomStyle = css`
-  &:before {
+  &:after {
     left: 50%;
     top: calc(100% + 5px);
     transform: translate(-50%, 0.5em);
   }
 `
 const leftStyle = css`
-  &:before {
+  &:after {
     top: 50%;
     right: calc(100% + 5px);
     left: calc(0em - 5px);
@@ -56,24 +57,23 @@ const sideStyles = {
 }
 
 const Tip = styled.span`
-  ${genericStyles}
-  display: ${({ show }) => (show ? 'block' : 'none')};
   /** Prop-based side styles */
   ${({ side }) => sideStyles[side]}
   /** Popup */
-  &:before {
-    display: block;
+  &:after {
+    ${genericStyles}
+    display: ${({ show }) => (show ? 'block' : 'none')};
     position: absolute;
     z-index: 1000;
     background-color: #FFF;
-    /** Popup Content */
-    content: "${({ text }) => text}";
     min-width: 160px;
     white-space: pre-wrap;
     padding: 4px 6px;
     border: 1px solid black;
     border-radius: 4px;
     box-shadow: 0 1em 2em -0.5em rgba(0, 0, 0, 0.35);
+    /** Popup Content */
+    content: "${({ text }) => text}";
   }
 `
 

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -1,11 +1,14 @@
 import styled, { css } from 'styled-components'
+import {
+  resolveMedia,
+  genericStyles,
+  responsiveProps,
+} from '../../utils/helpers'
 import { Anchor } from '../Anchor'
 
-const StyledTooltip = styled.div`
-  display: inline-block;
+const StyledTooltip = styled.span`
   position: relative;
   cursor: pointer;
-  white-space: nowrap;
 `
 
 const Icon = styled(Anchor)`
@@ -14,17 +17,64 @@ const Icon = styled(Anchor)`
   padding: 0.375rem;
 `
 
-const Tip = styled.div`
+const topStyle = css`
+  &:before {
+    left: 50%;
+    bottom: calc(100% + 5px);
+    transform: translate(-50%, -0.5em);
+  }
+`
+const rightStyle = css`
+  &:before {
+    top: 50%;
+    left: calc(100% + 5px);
+    right: calc(0em - 5px);
+    transform: translate(0.5em, -50%);
+  }
+`
+const bottomStyle = css`
+  &:before {
+    left: 50%;
+    top: calc(100% + 5px);
+    transform: translate(-50%, 0.5em);
+  }
+`
+const leftStyle = css`
+  &:before {
+    top: 50%;
+    right: calc(100% + 5px);
+    left: calc(0em - 5px);
+    transform: translate(-0.5em, -50%);
+  }
+`
+
+const sideStyles = {
+  top: topStyle,
+  right: rightStyle,
+  bottom: bottomStyle,
+  left: leftStyle,
+}
+
+const Tip = styled.span`
+  ${genericStyles}
   display: ${({ show }) => (show ? 'block' : 'none')};
-  position: absolute;
-  left: 0;
-  bottom: 20px;
-  z-index: 100;
-  min-width: 300px;
-  white-space: break-spaces;
-  background-color: white;
-  border: 1px solid black;
-  padding: 4px;
+  /** Prop-based side styles */
+  ${({ side }) => sideStyles[side]}
+  /** Popup */
+  &:before {
+    display: block;
+    position: absolute;
+    z-index: 1000;
+    background-color: #FFF;
+    /** Popup Content */
+    content: "${({ text }) => text}";
+    min-width: 160px;
+    white-space: pre-wrap;
+    padding: 4px 6px;
+    border: 1px solid black;
+    border-radius: 4px;
+    box-shadow: 0 1em 2em -0.5em rgba(0, 0, 0, 0.35);
+  }
 `
 
 export { StyledTooltip, Icon, Tip }

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -53,7 +53,7 @@ const sideStyles = {
 }
 
 const renderSide = sideProp => {
-  // string
+  // string - fixed width
   if (typeof sideProp === 'string') return sideStyles[sideProp]
   // responsive
   if (typeof sideProp === 'object') {
@@ -71,27 +71,27 @@ const Tip = styled.span`
   /** Popup */
   &:after {
     ${genericStyles}
+    /** conditional styles */
     display: ${({ show }) => (show ? 'block' : 'none')};
     ${({ minWidth }) => responsiveProps('min-width', minWidth)}
+    ${({ padding }) => !padding && `padding: 8px;`}
+    ${({ border }) => !border && `border: 1px solid black; border-radius: 4px;`}
+    /** positioning */
     position: absolute;
     z-index: 1000;
-    padding: 8px;
-    border: 1px solid black;
-    border-radius: 4px;
-    box-shadow: 0 1em 2em -0.5em rgba(0, 0, 0, 0.35);
-    /** Popup Content */
+    /** popup content */
     content: "${({ text }) => text}";
     /** text */
     font-size: 0.875rem;
     line-height: 1rem;
     white-space: pre-wrap;
     background-color: #FFF;
+    box-shadow: 0 1em 2em -0.5em rgba(0, 0, 0, 0.35);
   }
 `
 
 const Icon = styled(Anchor)`
   font-style: italic;
-  color: #428513;
   padding: 0.375rem;
 `
 

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -12,7 +12,7 @@ const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do e
   <Tooltip text={lorem} hover side="top">
     <Button text="Hover me!" />
   </Tooltip>
-  <Tooltip text={lorem} side="bottom">
+  <Tooltip text={lorem} side="bottom" minWidth={{xs: '150px', md: '250px'}}>
     Click me!
   </Tooltip>
   <Tooltip text={lorem} side={{xs: 'bottom', md:'left'}}>

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -15,5 +15,8 @@ const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do e
   <Tooltip text={lorem} side="bottom">
     Click me!
   </Tooltip>
+  <Tooltip text={lorem} side={{xs: 'bottom', md:'left'}}>
+    xs: bottom, md:left
+  </Tooltip>
 </Row>
 ```

--- a/src/components/Tooltip/Tooltip.md
+++ b/src/components/Tooltip/Tooltip.md
@@ -1,0 +1,19 @@
+Tooltip
+
+```jsx
+import { Tooltip, Row, Button, Paragraph as P } from '@moneypensionservice/directories';
+
+const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+
+<Row justify="space-evenly" align="center" direction="row">
+  <P width="auto" margin="0">
+    Default tooltip <Tooltip text={lorem} />
+  </P>
+  <Tooltip text={lorem} hover side="top">
+    <Button text="Hover me!" />
+  </Tooltip>
+  <Tooltip text={lorem} side="bottom">
+    Click me!
+  </Tooltip>
+</Row>
+```

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
 import { StyledTooltip, Icon, Tip } from './StyledTooltip'
 
-const Tooltip = ({ a11yTitle, children, hover, side, text, ...rest }) => {
+const Tooltip = ({ a11yTitle, children, hover, ...rest }) => {
   const [show, setShow] = useState(false)
 
   return (
@@ -14,7 +14,7 @@ const Tooltip = ({ a11yTitle, children, hover, side, text, ...rest }) => {
         onMouseEnter={() => hover && setShow(true)}
         onMouseLeave={() => hover && setShow(false)}
       >
-        <Tip show={show} text={text} side={side} {...rest}>
+        <Tip show={show} {...rest}>
           {children || (
             <Icon weight={700} color="#428513">
               i
@@ -31,13 +31,17 @@ Tooltip.propTypes = {
   /** Content inside component. If children are available inside the component they'll work as the trigger for it.s */
   children: PropTypes.node,
   hover: PropTypes.bool,
-  text: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  minWidth: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   side: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  text: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+
   ...genericPropTypes,
 }
 
 Tooltip.defaultProps = {
+  minWidth: '160px',
   side: 'right',
+
   ...genericPropsDefaults(),
 }
 

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
+import { StyledTooltip, Icon, Tip } from './StyledTooltip'
+
+const Tooltip = ({ a11yTitle, children, hover, text, ...rest }) => {
+  const [show, setShow] = useState(false)
+
+  return (
+    <StyledTooltip
+      aria-label={a11yTitle}
+      onClick={() => !hover && setShow(!show)}
+      onMouseEnter={() => hover && setShow(true)}
+      onMouseLeave={() => hover && setShow(false)}
+      {...rest}
+    >
+      {children || (
+        <Icon weight={700} color="#428513">
+          i
+        </Icon>
+      )}
+      <Tip show={show}>{text}</Tip>
+    </StyledTooltip>
+  )
+}
+
+// Documentation
+Tooltip.propTypes = {
+  /** Content inside component. If children are available inside the component they'll work as the trigger for it.s */
+  children: PropTypes.node,
+  hover: PropTypes.bool,
+  text: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  ...genericPropTypes,
+}
+
+Tooltip.defaultProps = {
+  ...genericPropsDefaults(),
+}
+
+/** @component */
+export { Tooltip }

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
 import { StyledTooltip, Icon, Tip } from './StyledTooltip'
 
-const Tooltip = ({ a11yTitle, children, hover, text, ...rest }) => {
+const Tooltip = ({ a11yTitle, children, hover, side, text, ...rest }) => {
   const [show, setShow] = useState(false)
 
   return (
@@ -12,14 +12,13 @@ const Tooltip = ({ a11yTitle, children, hover, text, ...rest }) => {
       onClick={() => !hover && setShow(!show)}
       onMouseEnter={() => hover && setShow(true)}
       onMouseLeave={() => hover && setShow(false)}
-      {...rest}
     >
       {children || (
         <Icon weight={700} color="#428513">
           i
         </Icon>
       )}
-      <Tip show={show}>{text}</Tip>
+      <Tip show={show} text={text} side={side} {...rest} />
     </StyledTooltip>
   )
 }
@@ -30,10 +29,12 @@ Tooltip.propTypes = {
   children: PropTypes.node,
   hover: PropTypes.bool,
   text: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  side: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
   ...genericPropTypes,
 }
 
 Tooltip.defaultProps = {
+  side: 'right',
   ...genericPropsDefaults(),
 }
 

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -7,22 +7,20 @@ const Tooltip = ({ a11yTitle, children, hover, ...rest }) => {
   const [show, setShow] = useState(false)
 
   return (
-    <>
-      <StyledTooltip
-        aria-label={a11yTitle}
-        onClick={() => !hover && setShow(!show)}
-        onMouseEnter={() => hover && setShow(true)}
-        onMouseLeave={() => hover && setShow(false)}
-      >
-        <Tip show={show} {...rest}>
-          {children || (
-            <Icon weight={700} color="#428513">
-              i
-            </Icon>
-          )}
-        </Tip>
-      </StyledTooltip>
-    </>
+    <StyledTooltip
+      aria-label={a11yTitle}
+      onClick={() => !hover && setShow(!show)}
+      onMouseEnter={() => hover && setShow(true)}
+      onMouseLeave={() => hover && setShow(false)}
+    >
+      <Tip show={show} {...rest}>
+        {children || (
+          <Icon weight={700} color="#428513">
+            i
+          </Icon>
+        )}
+      </Tip>
+    </StyledTooltip>
   )
 }
 
@@ -32,16 +30,14 @@ Tooltip.propTypes = {
   children: PropTypes.node,
   hover: PropTypes.bool,
   minWidth: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  side: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  side: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   text: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
-
   ...genericPropTypes,
 }
 
 Tooltip.defaultProps = {
   minWidth: '160px',
   side: 'right',
-
   ...genericPropsDefaults(),
 }
 

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -26,12 +26,16 @@ const Tooltip = ({ a11yTitle, children, hover, ...rest }) => {
 
 // Documentation
 Tooltip.propTypes = {
-  /** Content inside component. If children are available inside the component they'll work as the trigger for it.s */
+  /** Content inside component. If children are available inside the tooltip component they'll work as the trigger. */
   children: PropTypes.node,
+  /** If enabled, the tooltip will show on hover. */
   hover: PropTypes.bool,
+  /** Sets the minimum width of the tooltip. Responsive.e */
   minWidth: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  /** Defines the side where the tooltip shows. Responsive. */
   side: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  text: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  /** The text to display inside the Tooltip. */
+  text: PropTypes.string,
   ...genericPropTypes,
 }
 

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -7,19 +7,22 @@ const Tooltip = ({ a11yTitle, children, hover, side, text, ...rest }) => {
   const [show, setShow] = useState(false)
 
   return (
-    <StyledTooltip
-      aria-label={a11yTitle}
-      onClick={() => !hover && setShow(!show)}
-      onMouseEnter={() => hover && setShow(true)}
-      onMouseLeave={() => hover && setShow(false)}
-    >
-      {children || (
-        <Icon weight={700} color="#428513">
-          i
-        </Icon>
-      )}
-      <Tip show={show} text={text} side={side} {...rest} />
-    </StyledTooltip>
+    <>
+      <StyledTooltip
+        aria-label={a11yTitle}
+        onClick={() => !hover && setShow(!show)}
+        onMouseEnter={() => hover && setShow(true)}
+        onMouseLeave={() => hover && setShow(false)}
+      >
+        <Tip show={show} text={text} side={side} {...rest}>
+          {children || (
+            <Icon weight={700} color="#428513">
+              i
+            </Icon>
+          )}
+        </Tip>
+      </StyledTooltip>
+    </>
   )
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export { resolveMedia } from './utils/helpers'
 // controls
 export { default as Button } from './components/Button'
 export { Pagination } from './components/Pagination'
+export { Tooltip } from './components/Tooltip'
 // input
 export { Checkbox } from './components/Checkbox'
 export { Form } from './components/Form'

--- a/src/utils/helpers/responsive.js
+++ b/src/utils/helpers/responsive.js
@@ -27,11 +27,11 @@ export const responsiveProps = (property, values) => {
   } else if (typeof values === 'object') {
     return dimensions.map(d => {
       if (breakpoints[d] && values[d] !== undefined) {
-        console.log(typeof values[d])
+        console.log(property ? `${property}: ${values};` : `${values[d]}`)
         return css`
           ${breakpointStyle(
             breakpoints[d],
-            property ? `${property}: ${values};` : `${values[d]}`
+            property ? `${property}: ${values[d]};` : `${values[d]}`
           )}
         `
       }

--- a/src/utils/helpers/responsive.js
+++ b/src/utils/helpers/responsive.js
@@ -20,14 +20,19 @@ export const breakpointStyle = (breakpoint, content) => css`
  * @returns {string[]} The styles for the multiples breakpoints.
  */
 export const responsiveProps = (property, values) => {
+  if (!values) throw new Error('No values provided for responsive props!')
   if (typeof values === 'string') {
     // same values for all screen sizes
-    return `${property}: ${values};`
+    return property ? `${property}: ${values};` : `${values}`
   } else if (typeof values === 'object') {
     return dimensions.map(d => {
-      if (breakpoints[d] && values[d]) {
+      if (breakpoints[d] && values[d] !== undefined) {
+        console.log(typeof values[d])
         return css`
-          ${breakpointStyle(breakpoints[d], `${property}: ${values[d]};`)}
+          ${breakpointStyle(
+            breakpoints[d],
+            property ? `${property}: ${values};` : `${values[d]}`
+          )}
         `
       }
     })

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -72,6 +72,7 @@ module.exports = {
           components: () => [
             './src/components/Button/index.js',
             './src/components/Pagination/index.js',
+            './src/components/Tooltip/index.js',
           ],
         },
         {


### PR DESCRIPTION
[TP11074](https://maps.tpondemand.com/entity/11074-tooltip-component)

This PR implements the Tooltip Component. Some functionalities were added to this component such as the ability to trigger it on hover but also enabling to set the side where the tooltip shows and changing the minimum width of the tooltip.

In order to provide this functionality, small changes were made to the `responsiveProps` helper function.

**Note:** This component will not work for non-js users so a fallback should be provided in the consumer app.