### PR TITLE
11426 - Hide Generic Prop

### DIFF
--- a/src/components/Checkbox/StyledCheckbox.js
+++ b/src/components/Checkbox/StyledCheckbox.js
@@ -3,11 +3,13 @@ import { genericStyles } from '../../utils/helpers'
 
 const Label = styled.label`
   ${genericStyles}
-  ${props => !props.margin && `margin-bottom: 0.75rem;`}
-  ${props => props.disabled && `color: ${props.theme.colors.disabledText};`}
+  /** conditional styles */
+  ${({ margin }) => !margin && `margin-bottom: 0.75rem;`}
+  ${({ disabled, theme }) => disabled && `color: ${theme.colors.disabledText};`}
+  ${({ hide }) => !hide && `display: block;`}
   font-size: 1rem;
   line-height: 1.375rem;
-  display: block;
+  
 `
 
 const Field = styled.input`

--- a/src/components/Grid/Col/styledCol.js
+++ b/src/components/Grid/Col/styledCol.js
@@ -17,39 +17,37 @@ const gutterStyle = () => css`
   ${responsiveProps('padding', gridConfig.gutterWidth)}
 `
 
-const getSize = (props, size) => props.theme.sizes.size[size] || size
+const getSize = (theme, size) => theme.sizes.size[size] || size
 
 const ColWrapper = styled.div`
-  /** align-self, padding, margin, border */
   ${genericStyles}
   
-  display: flex;
   flex-wrap: ${props => props.flexWrap};
   max-width: 100%;
 
   /** column-based flex size */
-  ${props =>
-    props.sizesProp ? flexStyle(props.sizesProp) : 'flex-basis: auto;'}
+  ${({ sizesProp }) => (sizesProp ? flexStyle(sizesProp) : 'flex-basis: auto;')}
 
   /** conditional styles */
-  ${props => !props.sizesProp && `flex-grow: ${props.growProp ? 1 : 0};`}
-  ${props => props.debug && debugStyle()}
-  ${props => props.background && backgroundStyle(props.background)}
-  ${props => !props.padding && !props.noGutter && gutterStyle()}
+  ${({ hide }) => !hide && `display: flex;`}
+  ${({ sizesProp, growProp }) =>
+    !sizesProp && `flex-grow: ${growProp ? 1 : 0};`}
+  ${({ background }) => background && backgroundStyle(background)}
+  ${({ padding, noGutter }) => !padding && !noGutter && gutterStyle()}
 
   /** responsive props */
-  ${props =>
-    props.widthProp &&
-    responsiveProps('width', getSize(props, props.widthProp))}
-  ${props =>
-    props.heightProp &&
-    responsiveProps('height', getSize(props, props.heightProp))}
-  ${props =>
-    props.flexDirection &&
-    responsiveProps('flex-direction', props.flexDirection)}
+  ${({ widthProp, theme }) =>
+    widthProp && responsiveProps('width', getSize(theme, widthProp))}
+  ${({ heightProp, theme }) =>
+    heightProp && responsiveProps('height', getSize(theme, heightProp))}
+  ${({ flexDirection }) =>
+    flexDirection && responsiveProps('flex-direction', flexDirection)}
   ${props => props.align && responsiveProps('align-items', props.align)}
   ${props => props.justify && responsiveProps('justify-content', props.justify)}
   ${props => props.offsetProp && offsetStyle(props.offsetProp)}
+
+  /** debug */
+  ${({ debug }) => debug && debugStyle()}
 `
 
 export default ColWrapper

--- a/src/components/Grid/Container/styledContainer.js
+++ b/src/components/Grid/Container/styledContainer.js
@@ -48,34 +48,34 @@ const widthStyle = css`
 `
 
 const ContainerWrapper = styled.div`
-  /** align-self, padding, margin, border */
   ${genericStyles}
-
-  display: flex;
+  /** defaults */
   outline: none;
 
   /** conditional styles */
-  ${props => props.debug && debugStyle()}
-  ${props =>
-    !props.padding && responsiveProps('padding', gridConfig.containerPadding)}
-  ${props => !props.margin && 'margin: 0 auto;'}
-  ${props => props.background && backgroundStyle(props.background)}
-  ${props =>
-    props.heightProp &&
-    (typeof props.heightProp === 'object' ? heightObjectStyle : heightStyle)}
-  ${props =>
-    props.widthProp &&
-    (typeof props.widthProp === 'object' ? widthObjectStyle : widthStyle)}
-  ${props =>
-    !props.fluid &&
-    !props.widthProp &&
+  ${({ hide }) => !hide && `display: flex;`}
+  ${({ padding }) =>
+    !padding && responsiveProps('padding', gridConfig.containerPadding)}
+  ${({ margin }) => !margin && 'margin: 0 auto;'}
+  ${({ background }) => background && backgroundStyle(background)}
+  ${({ heightProp }) =>
+    heightProp &&
+    (typeof heightProp === 'object' ? heightObjectStyle : heightStyle)}
+  ${({ widthProp }) =>
+    widthProp &&
+    (typeof widthProp === 'object' ? widthObjectStyle : widthStyle)}
+  ${({ fluid, widthProp }) =>
+    !fluid &&
+    !widthProp &&
     responsiveProps('max-width', gridConfig.containerWidth)}
   ${props => !props.widthProp && props.fluid && 'width: 100%;'}
 
   /** responsive props */
-  ${props =>
-    props.flexDirection &&
-    responsiveProps('flex-direction', props.flexDirection)}
+  ${({ flexDirection }) =>
+    flexDirection && responsiveProps('flex-direction', flexDirection)}
+
+  /** debug */
+  ${({ debug }) => debug && debugStyle()}
 `
 
 export default ContainerWrapper

--- a/src/components/Grid/Row/styledRow.js
+++ b/src/components/Grid/Row/styledRow.js
@@ -15,15 +15,14 @@ const debugStyle = () => css`
 const RowWrapper = styled.div`
   /** align-self, padding, margin, border */
   ${genericStyles}
-
-  max-width: ${props => (props.constrained ? '1200px' : '100%')};
-  display: flex;
-  flex-wrap: ${props => props.flexWrap};
-  flex-grow: ${props => (props.growProp ? 1 : 0)};
+  /** defaults */
+  max-width: ${({ constrained }) => (constrained ? '1200px' : '100%')};
+  flex-wrap: ${({ flexWrap }) => flexWrap};
+  flex-grow: ${({ growProp }) => (growProp ? 1 : 0)};
 
   /** conditional styles */
-  ${props => props.debug && debugStyle()}
-  ${props => props.background && backgroundStyle(props.background)}
+  ${({ hide }) => !hide && `display: flex;`}
+  ${({ background }) => background && backgroundStyle(background)}
 
   /** responsive props */
   ${props =>
@@ -33,11 +32,13 @@ const RowWrapper = styled.div`
   ${props =>
     props.heightProp &&
     responsiveProps('height', getSize(props, props.heightProp))}
-  ${props =>
-    props.flexDirection &&
-    responsiveProps('flex-direction', props.flexDirection)}
-  ${props => props.align && responsiveProps('align-items', props.align)}
-  ${props => props.justify && responsiveProps('justify-content', props.justify)}
+  ${({ flexDirection }) =>
+    flexDirection && responsiveProps('flex-direction', flexDirection)}
+  ${({ align }) => align && responsiveProps('align-items', align)}
+  ${({ justify }) => justify && responsiveProps('justify-content', justify)}
+
+  /** debug */
+  ${({ debug }) => debug && debugStyle()}
 `
 
 export default RowWrapper

--- a/src/components/Pagination/StyledPagination.js
+++ b/src/components/Pagination/StyledPagination.js
@@ -4,10 +4,10 @@ import { Col } from '../Grid'
 import { Paragraph } from '../Paragraph'
 
 const StyledPagination = styled(Col)`
-  ${props => !props.margin && `margin: 0 auto;`}
+  ${({ margin }) => !margin && `margin: 0 auto;`}
 `
 const PaginationButton = styled(Button)`
-  ${props => props.noShow && `display: none;}`}
+  ${({ hide, noShow }) => !hide && noShow && `display: none;}`}
 `
 const PaginationCounter = styled(Paragraph)`
   margin: 0;

--- a/src/components/Radio/StyledRadio.js
+++ b/src/components/Radio/StyledRadio.js
@@ -3,10 +3,8 @@ import { genericStyles } from '../../utils/helpers'
 
 const Label = styled.label`
   ${genericStyles}
-  ${props =>
-    props.disabled &&
-    `color: ${props.theme.colors.disabledText};`}
-  display: block;
+  ${({ disabled, theme }) => disabled && `color: ${theme.colors.disabledText};`}
+  ${({ hide }) => !hide && `display: block;`}
 `
 
 const Field = styled.input`

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -3,53 +3,46 @@ import { genericStyles, responsiveProps } from '../../utils/helpers'
 import { Anchor } from '../Anchor'
 
 const StyledTooltip = styled.span`
+  ${genericStyles}
   position: relative;
   cursor: pointer;
 `
 
 /** Side styles for popup */
 const topStyle = css`
-  &:after {
-    top: auto;
-    right: auto;
-    left: 50%;
-    bottom: calc(100% + 5px);
-    transform: translate(-50%, -0.5em);
-  }
+  top: auto;
+  right: auto;
+  left: 50%;
+  bottom: calc(100% + 5px);
+  transform: translate(-50%, -0.5em);
 `
 const rightStyle = css`
-  &:after {
-    bottom: auto;
-    top: 50%;
-    left: calc(100% + 5px);
-    right: calc(0em - 5px);
-    transform: translate(0.5em, -50%);
-  }
+  bottom: auto;
+  top: 50%;
+  left: calc(100% + 5px);
+  right: calc(0em - 5px);
+  transform: translate(0.5em, -50%);
 `
 const bottomStyle = css`
-  &:after {
-    right: auto;
-    bottom: auto;
-    left: 50%;
-    top: calc(100% + 5px);
-    transform: translate(-50%, 0.5em);
-  }
+  right: auto;
+  bottom: auto;
+  left: 50%;
+  top: calc(100% + 5px);
+  transform: translate(-50%, 0.5em);
 `
 const leftStyle = css`
-  &:after {
-    bottom: auto;
-    left: auto;
-    top: 50%;
-    right: calc(100% + 5px);
-    transform: translate(-0.5em, -50%);
-  }
+  bottom: auto;
+  left: auto;
+  top: 50%;
+  right: calc(100% + 5px);
+  transform: translate(-0.5em, -50%);
 `
 
 const sideStyles = {
-  top: topStyle[0],
-  right: rightStyle[0],
-  bottom: bottomStyle[0],
-  left: leftStyle[0],
+  top: topStyle,
+  right: rightStyle,
+  bottom: bottomStyle,
+  left: leftStyle,
 }
 
 const renderSide = sideProp => {
@@ -66,22 +59,21 @@ const renderSide = sideProp => {
 }
 
 const Tip = styled.span`
-  /** Prop-based side styles */
-  ${({ side }) => renderSide(side)}
-  /** Popup */
+  /** Popup pseudo element */
   &:after {
-    ${genericStyles}
     /** conditional styles */
     display: ${({ show }) => (show ? 'block' : 'none')};
     ${({ minWidth }) => responsiveProps('min-width', minWidth)}
-    ${({ padding }) => !padding && `padding: 8px;`}
-    ${({ border }) => !border && `border: 1px solid black; border-radius: 4px;`}
     /** positioning */
     position: absolute;
     z-index: 1000;
+    /** Prop-based side styles */
+    ${({ side }) => renderSide(side)}
     /** popup content */
     content: "${({ text }) => text}";
-    /** text */
+    padding: 8px;
+    border: 1px solid black; 
+    border-radius: 4px;
     font-size: 0.875rem;
     line-height: 1rem;
     white-space: pre-wrap;

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -3,7 +3,15 @@ import PropTypes from 'prop-types'
 import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
 import { StyledTooltip, Icon, Tip } from './StyledTooltip'
 
-const Tooltip = ({ a11yTitle, children, hover, ...rest }) => {
+const Tooltip = ({
+  a11yTitle,
+  children,
+  hover,
+  minWidth,
+  side,
+  text,
+  ...rest
+}) => {
   const [show, setShow] = useState(false)
 
   return (
@@ -12,8 +20,9 @@ const Tooltip = ({ a11yTitle, children, hover, ...rest }) => {
       onClick={() => !hover && setShow(!show)}
       onMouseEnter={() => hover && setShow(true)}
       onMouseLeave={() => hover && setShow(false)}
+      {...rest}
     >
-      <Tip show={show} {...rest}>
+      <Tip minWidth={minWidth} show={show} side={side} text={text}>
         {children || (
           <Icon weight={700} color="#428513">
             i

--- a/src/docs/generic_props.md
+++ b/src/docs/generic_props.md
@@ -45,6 +45,26 @@ import { Container, Row, Col, Button } from '@moneypensionservice/directories';
 </Container>
 ```
 
+### **hide**
+
+> Hides the element when provided by adding `display: none` to the styles.
+
+```json
+Prop.Type: Boolean
+```
+
+```jsx
+import { useState } from 'react'
+import { Button } from '@moneypensionservice/directories';
+
+const [show, setShow] = useState(true);
+
+<Button 
+  hide={!show}
+  text='Click me!'
+  onClick={() => setShow(false)} />
+```
+
 ### **margin**
 
 > The amount of margin around the component. An object can be specified to distinguish horizontal margin, vertical margin, and margin on a particular side.

--- a/src/utils/helpers/responsive.js
+++ b/src/utils/helpers/responsive.js
@@ -27,7 +27,6 @@ export const responsiveProps = (property, values) => {
   } else if (typeof values === 'object') {
     return dimensions.map(d => {
       if (breakpoints[d] && values[d] !== undefined) {
-        console.log(property ? `${property}: ${values};` : `${values[d]}`)
         return css`
           ${breakpointStyle(
             breakpoints[d],

--- a/src/utils/helpers/styles.js
+++ b/src/utils/helpers/styles.js
@@ -4,11 +4,11 @@ import { ALIGN_SELF_MAP } from '../constants'
 
 // Returns the styles for generic props to be used in all components.
 export const genericStyles = css`
-  ${props =>
-    props.alignSelf && `align-self: ${ALIGN_SELF_MAP[props.alignSelf]};`}
-  ${props => props.margin && setStyle('margin', props.margin)}
-  ${props => props.padding && setStyle('padding', props.padding)}
-  ${props => props.border && borderStyle(props.border)}
+  ${({ alignSelf }) => alignSelf && `align-self: ${ALIGN_SELF_MAP[alignSelf]};`}
+  ${({ margin }) => margin && setStyle('margin', margin)}
+  ${({ padding }) => padding && setStyle('padding', padding)}
+  ${({ border }) => border && borderStyle(border)}
+  ${({ hide }) => hide && `display: none;`}
 `
 
 /**

--- a/src/utils/prop-types.js
+++ b/src/utils/prop-types.js
@@ -26,6 +26,7 @@ const spacingProp = PropTypes.shape({
 export const genericPropTypes = {
   a11yTitle: PropTypes.string,
   alignSelf: PropTypes.oneOf(['start', 'center', 'end', 'stretch']),
+  hide: PropTypes.bool,
   margin: PropTypes.oneOfType([
     PropTypes.oneOf(['none', ...SPACING_SIZES]),
     spacingProp,
@@ -49,6 +50,7 @@ export const genericPropTypes = {
 export function genericPropsDefaults({
   a11yTitle = null,
   alignSelf = null,
+  hide = false,
   margin = null,
   padding = null,
   border = null,
@@ -56,6 +58,7 @@ export function genericPropsDefaults({
   return {
     a11yTitle: a11yTitle,
     alignSelf: alignSelf,
+    hide: hide,
     margin: margin,
     padding: padding,
     border: border,


### PR DESCRIPTION
[TP11426](https://maps.tpondemand.com/entity/11426-hide-generic-prop)

This PR implements the new `hide` generic prop that adds `display:none` to the element's styles.

To avoid conflicts, every component with an explicit `display` property was modified to accommodate this new prop. Throughout every modified component, the `prop` argument was also destructed for readability.

The `Tooltip` component was slightly modified to have the `genericStyles` on the parent element and the `side` styles on the pseudo-element instead of outside of it. 

The `hide` prop documentation was also added to the generic props doc file.
