### PR TITLE
11427 - Footer Fallback Translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneypensionservice/directories",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Directories React Component Library",
   "homepage": "https://moneyadviceservice.github.io/react_library/",
   "repository": {

--- a/src/components/Footer/Footer.md
+++ b/src/components/Footer/Footer.md
@@ -12,7 +12,7 @@ const [locale, setLocale] = useState('en');
     <Button onClick={() => setLocale('cy')}>Welsh</Button>
   </Row>
   <Footer 
-    currentLgn={locale}
-    setLgn={() => setLocale(locale === 'en' ? 'cy' : 'en')} />
+    currentLng={locale}
+    setLng={() => setLocale(locale === 'en' ? 'cy' : 'en')} />
 </>
 ```

--- a/src/components/Footer/Footer.md
+++ b/src/components/Footer/Footer.md
@@ -13,6 +13,6 @@ const [locale, setLocale] = useState('en');
   </Row>
   <Footer 
     currentLgn={locale}
-    setLng={() => setLocale(locale === 'en' ? 'cy' : 'en')} />
+    setLgn={() => setLocale(locale === 'en' ? 'cy' : 'en')} />
 </>
 ```

--- a/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
+++ b/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
@@ -11,7 +11,7 @@ const FooterRow = styled(Row)`
 `
 
 const FooterSecondaryContainer = styled(Row)`
-  ${props => !props.padding && `padding: 20px 0;`}
+  ${props => !props.padding && `padding: 10px 0;`}
   color: white;
 `
 
@@ -72,6 +72,7 @@ const FooterSecondaryListItem = styled.li`
 const FooterAnchor = styled(Anchor)`
   color: white;
   font-size: 14px;
+  ${({ margin }) => !margin && `margin: 0;`}
 
   &:visited,
   &:hover {

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -11,15 +11,15 @@ import LocaleEn from './locale_en.json'
 import LocaleCy from './locale_cy.json'
 import LocaleContext from './LocaleContext'
 
-const Footer = ({ currentLgn, lngUrl, setLng, translations, ...rest }) => {
-  const i18n = translations || (currentLgn === 'cy' ? LocaleCy : LocaleEn)
+const Footer = ({ currentLgn, lngUrl, setLgn, i18nLgn, ...rest }) => {
+  const lgn = i18nLgn || (currentLgn === 'cy' ? LocaleCy : LocaleEn)
 
   return (
-    <LocaleContext.Provider value={i18n}>
+    <LocaleContext.Provider value={lgn}>
       <FooterContainer forwardedAs="footer" fluid {...rest}>
         <ContactPanels />
         <FooterPrimary />
-        <FooterSecondary lngUrl={lngUrl} setLng={setLng} />
+        <FooterSecondary lngUrl={lngUrl} setLng={setLgn} />
       </FooterContainer>
     </LocaleContext.Provider>
   )
@@ -31,9 +31,9 @@ Footer.propTypes = {
   /** Server-side fallback url to change language. */
   lngUrl: PropTypes.string,
   /** Function to be triggered by Locale Button. */
-  setLng: PropTypes.func,
+  setLgn: PropTypes.func,
   /** Implements custom translations for the Footer. */
-  translations: PropTypes.object,
+  i18nLgn: PropTypes.object,
   ...genericPropTypes,
 }
 Footer.defaultProps = {

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -12,7 +12,7 @@ import LocaleCy from './locale_cy.json'
 import LocaleContext from './LocaleContext'
 
 const Footer = ({ currentLgn, lngUrl, setLng, translations, ...rest }) => {
-  const i18n = translations || (currentLgn === 'en' ? LocaleEn : LocaleCy)
+  const i18n = translations || (currentLgn === 'cy' ? LocaleCy : LocaleEn)
 
   return (
     <LocaleContext.Provider value={i18n}>

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -11,8 +11,8 @@ import LocaleEn from './locale_en.json'
 import LocaleCy from './locale_cy.json'
 import LocaleContext from './LocaleContext'
 
-const Footer = ({ currentLgn, lngUrl, setLng, ...rest }) => {
-  const i18n = currentLgn === 'en' ? LocaleEn : LocaleCy
+const Footer = ({ currentLgn, lngUrl, setLng, translations, ...rest }) => {
+  const i18n = translations || (currentLgn === 'en' ? LocaleEn : LocaleCy)
 
   return (
     <LocaleContext.Provider value={i18n}>
@@ -26,12 +26,14 @@ const Footer = ({ currentLgn, lngUrl, setLng, ...rest }) => {
 }
 
 Footer.propTypes = {
-  /** Current Language Value */
+  /** Current Language Value. */
   currentLgn: PropTypes.oneOf(['en', 'cy']),
-  /** Function to be triggered by Locale Button */
-  setLng: PropTypes.func,
-  /** Server-side fallback url to change language */
+  /** Server-side fallback url to change language. */
   lngUrl: PropTypes.string,
+  /** Function to be triggered by Locale Button. */
+  setLng: PropTypes.func,
+  /** Implements custom translations for the Footer. */
+  translations: PropTypes.object,
   ...genericPropTypes,
 }
 Footer.defaultProps = {

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -11,15 +11,15 @@ import LocaleEn from './locale_en.json'
 import LocaleCy from './locale_cy.json'
 import LocaleContext from './LocaleContext'
 
-const Footer = ({ currentLgn, lngUrl, setLgn, i18nLgn, ...rest }) => {
-  const lgn = i18nLgn || (currentLgn === 'cy' ? LocaleCy : LocaleEn)
+const Footer = ({ currentLng, lngUrl, setLng, i18nLng, ...rest }) => {
+  const lng = i18nLng || (currentLng === 'cy' ? LocaleCy : LocaleEn)
 
   return (
-    <LocaleContext.Provider value={lgn}>
+    <LocaleContext.Provider value={lng}>
       <FooterContainer forwardedAs="footer" fluid {...rest}>
         <ContactPanels />
         <FooterPrimary />
-        <FooterSecondary lngUrl={lngUrl} setLng={setLgn} />
+        <FooterSecondary lngUrl={lngUrl} setLng={setLng} />
       </FooterContainer>
     </LocaleContext.Provider>
   )
@@ -27,17 +27,17 @@ const Footer = ({ currentLgn, lngUrl, setLgn, i18nLgn, ...rest }) => {
 
 Footer.propTypes = {
   /** Current Language Value. */
-  currentLgn: PropTypes.oneOf(['en', 'cy']),
+  currentLng: PropTypes.oneOf(['en', 'cy']),
   /** Server-side fallback url to change language. */
   lngUrl: PropTypes.string,
   /** Function to be triggered by Locale Button. */
-  setLgn: PropTypes.func,
+  setLng: PropTypes.func,
   /** Implements custom translations for the Footer. */
-  i18nLgn: PropTypes.object,
+  i18nLng: PropTypes.object,
   ...genericPropTypes,
 }
 Footer.defaultProps = {
-  currentLgn: 'en',
+  currentLng: 'en',
   ...genericPropsDefaults(),
 }
 


### PR DESCRIPTION
[TP11427](https://maps.tpondemand.com/entity/11427-provide-footer-fallback-translation-prop)

This PR implements the the `translations` prop to the `Footer` component that can be used to set custom translations, if no object is provided to this prop, the default translations will load instead.