### PR TITLE
11435 - Container Flex Props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneypensionservice/directories",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Directories React Component Library",
   "homepage": "https://moneyadviceservice.github.io/react_library/",
   "repository": {

--- a/src/components/Accordion/StyledAccordion.js
+++ b/src/components/Accordion/StyledAccordion.js
@@ -17,6 +17,7 @@ const AccordionBtn = styled(Col)`
   cursor: pointer;
   padding: 5px 12px;
   margin: 5px 0;
+  text-align: left;
   border: 1px solid transparent;
   border-radius: 3px;
   outline: none;
@@ -32,7 +33,7 @@ const AccordionBtn = styled(Col)`
 
 // Icon
 const Icon = styled(Chevron)`
-  width: 12px;
+  min-width: 12px;
   margin-right: 10px;
   transition: transform ease-out 0.3s;
   ${({ fillColor, theme }) => css`

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -44,6 +44,7 @@ const Accordion = ({
         direction="row"
         align="center"
         justify="flex-start"
+        flexWrap="nowrap"
         onClick={() => {
           setOpen(!open)
           if (onChange) onChange()

--- a/src/components/Footer/ContactPanels/StyledContactPanels.js
+++ b/src/components/Footer/ContactPanels/StyledContactPanels.js
@@ -10,8 +10,6 @@ import WebChatImg from '../../../assets/Images/chat.svg'
 
 // Contact Panel Row
 const ContactPanelRow = styled(Row)`
-  padding: 0;
-
   ${resolveMedia.xs`
     & > *:not(:last-child) {
       border-bottom: 1px solid #cbdae0;

--- a/src/components/Footer/FooterPrimary/StyledFooterPrimary.js
+++ b/src/components/Footer/FooterPrimary/StyledFooterPrimary.js
@@ -10,7 +10,7 @@ const FooterRow = styled(Row)`
     !props.background && `background-color: ${props.theme.colors.alternate};`}
 `
 
-const FooterPrimaryRow = styled(Row)`
+const FooterPrimaryContainer = styled(Col)`
   ${props => !props.padding && `padding: 24px 15px 12px;`}
 `
 
@@ -118,7 +118,7 @@ const Copyright = styled(Col)`
 
 export {
   FooterRow,
-  FooterPrimaryRow,
+  FooterPrimaryContainer,
   SocialContainer,
   SocialLink,
   SocialLogo,

--- a/src/components/Footer/FooterPrimary/index.js
+++ b/src/components/Footer/FooterPrimary/index.js
@@ -5,7 +5,7 @@ import {
 } from '../../../utils/prop-types'
 import {
   FooterRow,
-  FooterPrimaryRow,
+  FooterPrimaryContainer,
   SocialContainer,
   SocialLink,
   SocialLogo,
@@ -37,7 +37,7 @@ const FooterPrimary = () => {
 
   return (
     <FooterRow justify="center" padding="0">
-      <FooterPrimaryRow align="stretch" constrained>
+      <FooterPrimaryContainer align="stretch" direction="row" constrained>
         <SocialContainer
           sizes={{ xs: 12, md: 6 }}
           direction="row"
@@ -125,7 +125,7 @@ const FooterPrimary = () => {
             } ${copyright.address}`}
           </P>
         </Copyright>
-      </FooterPrimaryRow>
+      </FooterPrimaryContainer>
     </FooterRow>
   )
 }

--- a/src/components/Footer/FooterPrimary/index.js
+++ b/src/components/Footer/FooterPrimary/index.js
@@ -36,7 +36,7 @@ const FooterPrimary = () => {
   ).FooterPrimary
 
   return (
-    <FooterRow justify="center">
+    <FooterRow justify="center" padding="0">
       <FooterPrimaryRow align="stretch" constrained>
         <SocialContainer
           sizes={{ xs: 12, md: 6 }}

--- a/src/components/Footer/FooterPrimary/index.js
+++ b/src/components/Footer/FooterPrimary/index.js
@@ -113,7 +113,7 @@ const FooterPrimary = () => {
           </ClearEnglishContainer>
         </FooterLinks>
 
-        <Copyright padding="0">
+        <Copyright>
           <P
             textSize="1rem"
             lineHeight={{ xs: '1.2rem', md: '1.35rem' }}

--- a/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
+++ b/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
@@ -11,8 +11,12 @@ const FooterRow = styled(Row)`
 `
 
 const FooterSecondaryContainer = styled(Row)`
-  ${props => !props.padding && `padding: 10px 0;`}
+  ${props => !props.padding && `padding: 10px;`}
   color: white;
+
+  ${resolveMedia.sm`
+    ${props => !props.padding && `padding: 10px 15px;`}
+  `}
 `
 
 // accessibility section

--- a/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
+++ b/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
@@ -65,11 +65,11 @@ const FooterSecondaryList = styled.ul`
 
   &:not(:last-child) {
     margin-right: 6px;
+    padding-right: 12px;
   }
 `
 
 const FooterSecondaryListItem = styled.li`
-  padding-right: 12px;
   margin-top: 6px;
 `
 

--- a/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
+++ b/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
@@ -57,20 +57,24 @@ const MapsLink = styled(Col)`
 const ListContainer = styled(Col)`
   flex-grow: 0;
 `
+const FooterSecondaryListItem = styled.li`
+  margin-top: 6px;
+`
 
 const FooterSecondaryList = styled.ul`
   display: flex;
   flex-wrap: inherit;
   margin: 6px 0;
 
-  &:not(:last-child) {
+  ${FooterSecondaryListItem} {
     margin-right: 6px;
     padding-right: 12px;
   }
-`
 
-const FooterSecondaryListItem = styled.li`
-  margin-top: 6px;
+  ${FooterSecondaryListItem}:last-child {
+    margin-right: 0;
+    padding-right: 0;
+  }
 `
 
 const FooterAnchor = styled(Anchor)`

--- a/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
+++ b/src/components/Footer/FooterSecondary/StyledFooterSecondary.js
@@ -10,7 +10,7 @@ const FooterRow = styled(Row)`
     !props.background && `background-color: ${props.theme.colors.mapsBlue};`}
 `
 
-const FooterSecondaryContainer = styled(Row)`
+const FooterSecondaryContainer = styled(Col)`
   ${props => !props.padding && `padding: 10px;`}
   color: white;
 

--- a/src/components/Footer/FooterSecondary/index.js
+++ b/src/components/Footer/FooterSecondary/index.js
@@ -27,7 +27,7 @@ const FooterSecondary = ({ lngUrl, setLng }) => {
   ).FooterSecondary
 
   return (
-    <FooterRow justify="center">
+    <FooterRow justify="center" padding="0">
       <FooterSecondaryContainer
         justify="space-between"
         align="center"

--- a/src/components/Footer/FooterSecondary/index.js
+++ b/src/components/Footer/FooterSecondary/index.js
@@ -29,6 +29,7 @@ const FooterSecondary = ({ lngUrl, setLng }) => {
   return (
     <FooterRow justify="center" padding="0">
       <FooterSecondaryContainer
+        direction="row"
         justify="space-between"
         align="center"
         constrained

--- a/src/components/Grid/Col/index.js
+++ b/src/components/Grid/Col/index.js
@@ -92,6 +92,8 @@ Col.propTypes = {
   ]),
   /** Content inside element. */
   children: PropTypes.node,
+  /** Applies default max-width */
+  constrained: PropTypes.bool,
   /** Enables debug styles. */
   debug: PropTypes.bool,
   /** The orientation to layout the child components in. 'column', 'row', 'column-reverse', 'row-reverse' */
@@ -166,6 +168,7 @@ Col.propTypes = {
 
 Col.defaultProps = {
   align: 'stretch',
+  constrained: false,
   debug: false,
   direction: 'column',
   flexWrap: 'wrap',

--- a/src/components/Grid/Col/styledCol.js
+++ b/src/components/Grid/Col/styledCol.js
@@ -23,7 +23,8 @@ const ColWrapper = styled.div`
   ${genericStyles}
   
   flex-wrap: ${props => props.flexWrap};
-  max-width: 100%;
+  max-width: ${({ constrained }) =>
+    constrained ? gridConfig.constrained : '100%'};
 
   /** column-based flex size */
   ${({ sizesProp }) => (sizesProp ? flexStyle(sizesProp) : 'flex-basis: auto;')}

--- a/src/components/Grid/Container/index.js
+++ b/src/components/Grid/Container/index.js
@@ -9,25 +9,33 @@ import ContainerWrapper from './styledContainer'
 
 function Container({
   a11yTitle,
+  align,
   as,
   background,
   children,
   debug,
   flexDirection = 'column',
+  flexWrap,
   fluid,
+  grow,
   height,
+  justify,
   width,
   ...rest
 }) {
   return (
     <ContainerWrapper
+      align={align}
       aria-label={a11yTitle}
       as={as}
       background={background}
       debug={debug}
       flexDirection={flexDirection}
+      flexWrap={flexWrap}
       fluid={fluid}
+      growProp={grow}
       heightProp={height}
+      justify={justify}
       widthProp={width}
       {...rest}
     >
@@ -38,6 +46,23 @@ function Container({
 
 // Documentation
 Container.propTypes = {
+  /**	Align the contents along the cross axis. 'stretch', 'flex-start', 'flex-end', 'center', 'baseline', 'first baseline', 'last baseline', 'start', 'end', 'self-start', 'self-end' */
+  align: PropTypes.oneOfType([
+    PropTypes.oneOf([
+      'stretch',
+      'flex-start',
+      'flex-end',
+      'center',
+      'baseline',
+      'first baseline',
+      'last baseline',
+      'start',
+      'end',
+      'self-start',
+      'self-end',
+    ]),
+    PropTypes.object,
+  ]),
   /** The DOM tag or react component to use for the element. */
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   /** A color identifier or url to use for the background or image. */
@@ -61,8 +86,12 @@ Container.propTypes = {
     PropTypes.oneOf(['column', 'row', 'column-reverse', 'row-reverse']),
     PropTypes.object,
   ]),
+  /** Whether children can wrap if they can't all fit. */
+  flexWrap: PropTypes.oneOf(['nowrap', 'wrap', 'wrap-reverse']),
   /** Makes container full-width across all viewport and device sizes. */
   fluid: PropTypes.bool,
+  /** Flex Grow. */
+  grow: PropTypes.bool,
   /** Set a fixed height. 'xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge', any CSS value */
   height: PropTypes.oneOfType([
     PropTypes.oneOf([
@@ -75,6 +104,22 @@ Container.propTypes = {
       'xxlarge',
     ]),
     PropTypes.string,
+    PropTypes.object,
+  ]),
+  /**	Align the contents along the main axis. 'flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly', 'start', 'end', 'left', 'right' */
+  justify: PropTypes.oneOfType([
+    PropTypes.oneOf([
+      'flex-start',
+      'flex-end',
+      'center',
+      'space-between',
+      'space-around',
+      'space-evenly',
+      'start',
+      'end',
+      'left',
+      'right',
+    ]),
     PropTypes.object,
   ]),
   /** Set a fixed width. 'xxsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge', any CSS value  */
@@ -97,7 +142,9 @@ Container.propTypes = {
 Container.defaultProps = {
   debug: false,
   flexDirection: 'column',
+  flexWrap: 'nowrap',
   fluid: false,
+  grow: true,
   ...genericPropsDefaults(),
 }
 

--- a/src/components/Grid/Container/styledContainer.js
+++ b/src/components/Grid/Container/styledContainer.js
@@ -51,12 +51,24 @@ const ContainerWrapper = styled.div`
   ${genericStyles}
   /** defaults */
   outline: none;
+  ${({ padding }) =>
+    !padding &&
+    css`
+      padding: 0;
+    `}
 
   /** conditional styles */
-  ${({ hide }) => !hide && `display: flex;`}
-  ${({ padding }) =>
-    !padding && responsiveProps('padding', gridConfig.containerPadding)}
-  ${({ margin }) => !margin && 'margin: 0 auto;'}
+  ${({ hide }) =>
+    !hide &&
+    css`
+      display: flex;
+    `}
+  
+  ${({ margin }) =>
+    !margin &&
+    css`
+      margin: 0 auto;
+    `}
   ${({ background }) => background && backgroundStyle(background)}
   ${({ heightProp }) =>
     heightProp &&
@@ -64,15 +76,34 @@ const ContainerWrapper = styled.div`
   ${({ widthProp }) =>
     widthProp &&
     (typeof widthProp === 'object' ? widthObjectStyle : widthStyle)}
+  ${({ growProp }) =>
+    growProp &&
+    css`
+      flex-grow: ${growProp ? 1 : 0};
+    `}
+  ${({ flexWrap }) =>
+    flexWrap &&
+    css`
+      flex-wrap: ${flexWrap};
+    `}
+  
+  /** fluid states */
   ${({ fluid, widthProp }) =>
     !fluid &&
     !widthProp &&
     responsiveProps('max-width', gridConfig.containerWidth)}
-  ${props => !props.widthProp && props.fluid && 'width: 100%;'}
+  ${props =>
+    !props.widthProp &&
+    props.fluid &&
+    css`
+      width: 100%;
+    `}
 
   /** responsive props */
   ${({ flexDirection }) =>
     flexDirection && responsiveProps('flex-direction', flexDirection)}
+  ${({ align }) => align && responsiveProps('align-items', align)}
+  ${({ justify }) => justify && responsiveProps('justify-content', justify)}
 
   /** debug */
   ${({ debug }) => debug && debugStyle()}

--- a/src/components/Grid/Row/styledRow.js
+++ b/src/components/Grid/Row/styledRow.js
@@ -18,8 +18,9 @@ const RowWrapper = styled.div`
   ${genericStyles}
 
   /** defaults */
-  max-width: ${({ constrained }) => (constrained ? '1200px' : '100%')};
-  flex-grow: ${({ growProp }) => (growProp ? 1 : 0)};
+  max-width: ${({ constrained }) =>
+    constrained ? gridConfig.constrained : '100%'};
+  flex-grow: ${({ growProp }) => (growProp ? 1 : 0)}; 
   ${({ flexWrap }) =>
     flexWrap &&
     css`

--- a/src/components/Grid/Row/styledRow.js
+++ b/src/components/Grid/Row/styledRow.js
@@ -4,6 +4,7 @@ import {
   backgroundStyle,
   responsiveProps,
 } from '../../../utils/helpers'
+import { gridConfig } from '../config'
 
 const getSize = (props, size) => props.theme.sizes.size[size] || size
 
@@ -15,16 +16,23 @@ const debugStyle = () => css`
 const RowWrapper = styled.div`
   /** align-self, padding, margin, border */
   ${genericStyles}
+
   /** defaults */
   max-width: ${({ constrained }) => (constrained ? '1200px' : '100%')};
-  flex-wrap: ${({ flexWrap }) => flexWrap};
   flex-grow: ${({ growProp }) => (growProp ? 1 : 0)};
-
+  ${({ flexWrap }) =>
+    flexWrap &&
+    css`
+      flex-wrap: ${flexWrap};
+    `}
+  
   /** conditional styles */
   ${({ hide }) => !hide && `display: flex;`}
   ${({ background }) => background && backgroundStyle(background)}
 
   /** responsive props */
+  ${({ padding }) =>
+    !padding && responsiveProps('padding', gridConfig.rowPadding)}
   ${props =>
     props.widthProp
       ? responsiveProps('width', getSize(props, props.widthProp))

--- a/src/components/Grid/config.js
+++ b/src/components/Grid/config.js
@@ -1,16 +1,16 @@
 export const gridConfig = {
-  // col gutter
-  gutterWidth: {
-    xs: '0 10px',
-    sm: '0 15px',
-  },
-  // container padding
-  containerPadding: {
-    xs: '0 15px',
-  },
   // container max-width
   containerWidth: {
     xs: '100%',
     lg: '1440px',
+  },
+  rowPadding: {
+    xs: '0 10px',
+    sm: '0 15px',
+  },
+  // col gutter
+  gutterWidth: {
+    xs: '0 10px',
+    sm: '0 15px',
   },
 }

--- a/src/components/Grid/config.js
+++ b/src/components/Grid/config.js
@@ -13,4 +13,5 @@ export const gridConfig = {
     xs: '0 10px',
     sm: '0 15px',
   },
+  constrained: '1200px',
 }

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -22,7 +22,7 @@ const Header = ({
         <Row
           justify="space-between"
           align="center"
-          padding="12px 0"
+          padding="12px 15px"
           margin="auto"
           constrained
         >


### PR DESCRIPTION
[TP11435](https://maps.tpondemand.com/entity/11435-add-flex-props-to-container)

This PR initially aimed to add the missing `flexbox` props and styles to the `Container` but I decided to also fix some of the issues with the `padding` and `margin` properties on the `Grid` components as well:

- Adds flex props to Container;
- Removes `padding` and `margin` on `Container` component and adjust their values on the grid config file;
- Modifies `padding` and `margin` values in the grid config for the `Row` and `Col` components to adjust to changes on the `Container`;
- Restructures the `Footer` component to reflect these changes and makes the `margin` and `padding` much more consistent between its various elements;
- Adds the `constrained` prop to the `Col` component and creates a variable for the `max-width` value on the grid config for consistency;
- Finally, also fixed an issue on the `Accordion` component when the `title` is over a line long.

With these changes in place we now have better consistency on the Grid components and can now use them as intended: `Container > Row > Col`.