### PR TITLE
11515 - Accordion Component Adjustments

### DIFF
--- a/src/components/Accordion/Accordion.md
+++ b/src/components/Accordion/Accordion.md
@@ -11,7 +11,7 @@ const lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent
   <Accordion title="Custom Content">
     {lorem}
   </Accordion>
-  <Accordion title="Using other components inside">
+  <Accordion noBorder title="Using other components inside">
     <Button text="I'm inside the Accordion!" />
   </Accordion>
   <Accordion text={lorem} title="Custom color" color="red" />

--- a/src/components/Accordion/Accordion.md
+++ b/src/components/Accordion/Accordion.md
@@ -6,14 +6,40 @@ import { Accordion, Button, Row } from '@moneypensionservice/directories';
 
 const lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent faucibus, sapien id euismod suscipit, felis massa gravida lorem, a lacinia ipsum ipsum a neque. Cras nec pulvinar ligula. Pellentesque sollicitudin, nibh non ultricies ultrices, nulla eros tristique ligula, quis bibendum metus quam congue diam. Aenean tincidunt, purus eu mattis aliquam, mauris elit rhoncus lectus, at venenatis diam urna at turpis. Nam tempor, nisl et dignissim finibus, leo diam scelerisque est, eget rutrum risus sapien quis massa. Praesent condimentum ex vitae tincidunt eleifend. Nunc vehicula tellus ut nisi laoreet vulputate. Fusce luctus dui eu scelerisque euismod. Quisque aliquet lorem egestas elit faucibus commodo. In dictum at lectus ac auctor.";
 
+const [activeIndex, changeIndex] = useState(0);
+
+const handleClick = (current) => {
+  const newIndex = activeIndex === current ? -1 : current
+  changeIndex(newIndex)
+}
+
 <Row direction="column">
-  <Accordion text={lorem} title="Opened by default" openByDefault />
-  <Accordion title="Custom Content">
+  <Accordion 
+    text={lorem} 
+    title="Outside" />
+  <Accordion 
+    text={lorem} 
+    title="Opened by default" 
+    active={activeIndex === 0}
+    onClick={() => handleClick(0)} />
+  <Accordion 
+    title="Custom Content"
+    active={activeIndex === 1}
+    onClick={() => handleClick(1)} >
     {lorem}
   </Accordion>
-  <Accordion noBorder title="Using other components inside">
+  <Accordion 
+    noBorder 
+    title="Using other components inside"
+    active={activeIndex === 2}
+    onClick={() => handleClick(2)} >
     <Button text="I'm inside the Accordion!" />
   </Accordion>
-  <Accordion text={lorem} title="Custom color" color="red" />
+  <Accordion 
+    text={lorem} 
+    title="Custom color" 
+    color="red"
+    active={activeIndex === 3}
+    onClick={() => handleClick(3)} />
 </Row>
 ```

--- a/src/components/Accordion/StyledAccordion.js
+++ b/src/components/Accordion/StyledAccordion.js
@@ -33,8 +33,9 @@ const AccordionBtn = styled(Col)`
 
 // Icon
 const Icon = styled(Chevron)`
+  align-self: flex-start;
   min-width: 12px;
-  margin-right: 10px;
+  margin: 3px 10px 0 0;
   transition: transform ease-out 0.3s;
   ${({ fillcolor, theme }) => css`
     fill: ${fillcolor ? fillcolor : theme.colors.accordion.default};

--- a/src/components/Accordion/StyledAccordion.js
+++ b/src/components/Accordion/StyledAccordion.js
@@ -54,6 +54,28 @@ const ContentContainer = styled(Col)`
   transition: ease-out 0.3s;
   opacity: 1;
 
+  ${({ hideBorder, borderColor, theme }) =>
+    !hideBorder &&
+    css`
+      border-left-width: 5px;
+      border-left-style: solid;
+      border-left-color: ${borderColor
+        ? borderColor
+        : theme.colors.accordion.default};
+    `}
+
+  ${({ padding }) =>
+    !padding &&
+    css`
+      padding-left: 10px;
+    `}
+
+  ${({ margin }) =>
+    !margin &&
+    css`
+      margin-left: 15px;
+    `}
+
   ${({ show }) =>
     !show &&
     css`
@@ -68,20 +90,6 @@ const ContentContainer = styled(Col)`
 `
 
 const Content = styled(Paragraph)`
-  ${({ border, borderColor, theme }) =>
-    !border &&
-    css`
-      border-left-width: 5px;
-      border-left-style: solid;
-      border-left-color: ${borderColor
-        ? borderColor
-        : theme.colors.accordion.default};
-    `}
-  ${({ padding }) =>
-    !padding &&
-    css`
-      padding-left: 10px;
-    `}
   ${({ margin }) =>
     !margin &&
     css`

--- a/src/components/Accordion/StyledAccordion.js
+++ b/src/components/Accordion/StyledAccordion.js
@@ -41,7 +41,7 @@ const Icon = styled(Chevron)`
   `}
 
   ${({ isopen }) =>
-    isopen === 'true' &&
+    isopen &&
     css`
       transform: rotate(90deg);
     `}

--- a/src/components/Accordion/StyledAccordion.js
+++ b/src/components/Accordion/StyledAccordion.js
@@ -36,12 +36,12 @@ const Icon = styled(Chevron)`
   min-width: 12px;
   margin-right: 10px;
   transition: transform ease-out 0.3s;
-  ${({ fillColor, theme }) => css`
-    fill: ${fillColor ? fillColor : theme.colors.accordion.default};
+  ${({ fillcolor, theme }) => css`
+    fill: ${fillcolor ? fillcolor : theme.colors.accordion.default};
   `}
 
-  ${({ isOpen }) =>
-    isOpen &&
+  ${({ isopen }) =>
+    isopen === 'true' &&
     css`
       transform: rotate(90deg);
     `}

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -16,6 +16,7 @@ const Accordion = ({
   color,
   text,
   title,
+  noBorder,
   onChange,
   openByDefault,
   ...rest
@@ -56,12 +57,14 @@ const Accordion = ({
         </Paragraph>
       </AccordionBtn>
       <ContentContainer
+        borderColor={color}
+        hideBorder={noBorder}
         show={open}
         ref={c => {
           currentContent = c
         }}
       >
-        {text && <Content borderColor={color}>{text}</Content>}
+        {text && <Content>{text}</Content>}
         {children}
       </ContentContainer>
     </StyledAccordion>
@@ -78,6 +81,8 @@ Accordion.propTypes = {
   text: PropTypes.string,
   /** Title of the accordion. */
   title: PropTypes.string,
+  /** Removes border from content. */
+  noBorder: PropTypes.bool,
   /** Callback when the accordion state changes. */
   onChange: PropTypes.func,
   /** Set accordion to be opened by default. */
@@ -86,6 +91,7 @@ Accordion.propTypes = {
 }
 
 Accordion.defaultProps = {
+  noBorder: false,
   openByDefault: false,
   ...genericPropsDefaults(),
 }

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -12,17 +12,17 @@ import {
 
 const Accordion = ({
   a11yTitle,
+  active,
   children,
   color,
   text,
   title,
   noBorder,
   onChange,
-  openByDefault,
   ...rest
 }) => {
-  // set default open state to true
-  const [open, setOpen] = useState(openByDefault)
+  // set open state
+  const [open, setOpen] = useState(false)
   const contentRef = useRef(null)
   let currentContent = null
 
@@ -32,6 +32,11 @@ const Accordion = ({
       ? `${currentContent.scrollHeight}px`
       : (currentContent.style.height = '0')
   }, [contentRef, open])
+
+  // manage open state when active prop is used
+  useEffect(() => {
+    setOpen(active)
+  }, [active])
 
   return (
     <StyledAccordion
@@ -46,12 +51,12 @@ const Accordion = ({
         align="center"
         justify="flex-start"
         flexWrap="nowrap"
-        onClick={() => {
+        onClick={e => {
           setOpen(!open)
           if (onChange) onChange()
         }}
       >
-        <Icon fillcolor={color} isopen={open.toString()} />
+        <Icon fillcolor={color} isopen={open ? 1 : 0} />
         <Paragraph color={color} margin="0" width="auto">
           {title}
         </Paragraph>
@@ -73,6 +78,8 @@ const Accordion = ({
 
 // Documentation
 Accordion.propTypes = {
+  /** Set accordion to be opened if true. */
+  active: PropTypes.bool,
   /** Color for the chevron. */
   color: PropTypes.string,
   /** The children elements to render within the acordion. */
@@ -85,14 +92,11 @@ Accordion.propTypes = {
   noBorder: PropTypes.bool,
   /** Callback when the accordion state changes. */
   onChange: PropTypes.func,
-  /** Set accordion to be opened by default. */
-  openByDefault: PropTypes.bool,
   ...genericPropTypes,
 }
 
 Accordion.defaultProps = {
   noBorder: false,
-  openByDefault: false,
   ...genericPropsDefaults(),
 }
 

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -50,7 +50,7 @@ const Accordion = ({
           if (onChange) onChange()
         }}
       >
-        <Icon fillColor={color} isOpen={open} />
+        <Icon fillcolor={color} isopen={open.toString()} />
         <Paragraph color={color} margin="0" width="auto">
           {title}
         </Paragraph>


### PR DESCRIPTION
[TP11515](https://maps.tpondemand.com/entity/11515-accordion-error-messages-and-proptypes)

In this PR some adjustments were made to the `Accordion` component:

- Fixes the existing error messages for the `fillColor` and `isOpen` props for the chevron SVG;
- Moved the content border from the `Paragraph` element to the content container, this way if children are used to display content then the border still shows;
- Added the `hideBorder` prop to remove the content border;
- Renamed the `openByDefault` prop to `active` and implemented logic to enable the functionality to have only one `Accordion` opened at a time;
- Improved the documentation to show the new functionality in action;
- Adjusted the chevron position when the title has two or more lines of text.