### PR TITLE
Rollup Font Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneypensionservice/directories",
-  "version": "1.6.1",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15600,6 +15600,24 @@
         "jest-worker": "^24.0.0",
         "serialize-javascript": "^2.1.2",
         "uglify-js": "^3.4.9"
+      }
+    },
+    "rollup-plugin-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-url/-/rollup-plugin-url-3.0.1.tgz",
+      "integrity": "sha512-fQVrxlW335snHfPqZ7a0JIkkYEIrLeFobpAxRMQnyv7xQeJOY1yOd84STIdCaLYPoGzwOq8waOdGipNH181kzg==",
+      "dev": true,
+      "requires": {
+        "mime": "^2.4.4",
+        "rollup-pluginutils": "^2.8.2"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+          "dev": true
+        }
       }
     },
     "rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "rollup-plugin-peer-deps-external": "^2.2.2",
     "rollup-plugin-terser": "^5.2.0",
     "rollup-plugin-uglify": "^6.0.4",
+    "rollup-plugin-url": "^3.0.1",
     "url-loader": "^3.0.0",
     "webpack": "^4.41.6"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ import { uglify } from 'rollup-plugin-uglify'
 import packageJSON from './package.json'
 import json from '@rollup/plugin-json'
 import svgr from '@svgr/rollup'
+import url from 'rollup-plugin-url'
 
 const input = './src/index.js'
 const minifyExtension = pathToFile => pathToFile.replace(/\.js$/, '.min.js')
@@ -23,6 +24,10 @@ export default [
     plugins: [
       json(),
       svgr(),
+      url({
+        include: ['**/*.woff', '**/*.woff2'],
+        limit: Infinity,
+      }),
       babel({
         exclude: 'node_modules/**',
         runtimeHelpers: true,
@@ -42,6 +47,10 @@ export default [
     plugins: [
       json(),
       svgr(),
+      url({
+        include: ['**/*.woff', '**/*.woff2'],
+        limit: Infinity,
+      }),
       babel({
         exclude: 'node_modules/**',
         runtimeHelpers: true,
@@ -67,6 +76,10 @@ export default [
     plugins: [
       json(),
       svgr(),
+      url({
+        include: ['**/*.woff', '**/*.woff2'],
+        limit: Infinity,
+      }),
       babel({
         exclude: 'node_modules/**',
         runtimeHelpers: true,
@@ -90,6 +103,10 @@ export default [
     plugins: [
       json(),
       svgr(),
+      url({
+        include: ['**/*.woff', '**/*.woff2'],
+        limit: Infinity,
+      }),
       babel({
         exclude: 'node_modules/**',
         runtimeHelpers: true,
@@ -111,6 +128,10 @@ export default [
     plugins: [
       json(),
       svgr(),
+      url({
+        include: ['**/*.woff', '**/*.woff2'],
+        limit: Infinity,
+      }),
       babel({
         exclude: 'node_modules/**',
         runtimeHelpers: true,
@@ -130,6 +151,10 @@ export default [
     plugins: [
       json(),
       svgr(),
+      url({
+        include: ['**/*.woff', '**/*.woff2'],
+        limit: Infinity,
+      }),
       babel({
         exclude: 'node_modules/**',
         runtimeHelpers: true,


### PR DESCRIPTION
Due to some changes on the last PR where the global fonts are now correctly imported into the app, support for these font files needs to be provided to Rollup to bundle these into the package.