### PR TITLE
11752 - NotFound Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneypensionservice/directories",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Directories React Component Library",
   "homepage": "https://moneyadviceservice.github.io/react_library/",
   "repository": {

--- a/src/components/CompanyCard/CompanyCard.md
+++ b/src/components/CompanyCard/CompanyCard.md
@@ -40,7 +40,7 @@ const firm = {
       specialises_in: 'cancer'
     },
     medical_equipment_cover: {
-      cover_amount: 1000,
+      cover_amount: 1000000,
       offers_cover: true
     },
     medical_screening_company: 'verisik'

--- a/src/components/CompanyCard/index.js
+++ b/src/components/CompanyCard/index.js
@@ -119,7 +119,7 @@ const CompanyCard = ({
                 {lng.openingTimes.title}
                 <Tooltip
                   text={openingHoursTooltip(opening_times, lng)}
-                  minWidth={currentLng === 'cy' ? '275px' : '230px'}
+                  minWidth={currentLng === 'cy' ? '235px' : '185px'}
                   margin={{ left: '5px' }}
                 />
               </Info>

--- a/src/components/CompanyCard/index.js
+++ b/src/components/CompanyCard/index.js
@@ -61,11 +61,11 @@ const CompanyCard = ({
   // locale
   const lng = i18nLng || (currentLng === 'cy' ? LocaleCy : LocaleEn)
   // destructure firm data from prop
-  const { company, online, opening_times, overview } = data
+  const { company, online, opening_times, overview } = { ...data }
   // get in touch data
-  const { phone, website, email } = online
+  const { phone, website, email } = { ...online }
   // opening times data
-  const { week_days, saturdays, sundays } = opening_times
+  const { week_days, saturdays, sundays } = { ...opening_times }
   // overview data
   const {
     coronavirus_cancellation_cover,
@@ -74,25 +74,30 @@ const CompanyCard = ({
     medical_conditions_cover,
     medical_equipment_cover,
     medical_screening_company,
-  } = overview
+  } = { ...overview }
 
-  return (
+  return company || online || overview ? (
     <CardContainer aria-label={a11yTitle || company} {...rest}>
       <CardRow>
         <CardCol margin={{ bottom: '20px' }}>
-          <CompanyTitle level={2} margin="0">
-            {company}
-          </CompanyTitle>
+          {company ? (
+            <CompanyTitle level={2} margin="0">
+              {company}
+            </CompanyTitle>
+          ) : (
+            <Info>{lng.company.noInfo}</Info>
+          )}
         </CardCol>
       </CardRow>
       <CardRow>
         {/** Left Column */}
         <CardCol sizes={{ xs: 12, sm: 3 }}>
           {/** Buttons */}
+          {!online && <Info>{lng.getInTouch.noInfo}</Info>}
           {phone && (
-            <CardButton href={`tel:${phone}`}>
+            <CardButton href={`tel:${phone.replace(/\s/g, '')}`}>
               <PhoneIcon />
-              {phone}
+              {phone.replace(/\s/g, '')}
             </CardButton>
           )}
           {website && (
@@ -108,19 +113,21 @@ const CompanyCard = ({
             </CardButton>
           )}
           {/** Opening Times */}
-          {(week_days.opens || saturdays.opens || sundays.opens) && (
-            <Info margin={{ top: '5px' }}>
-              {lng.openingTimes.title}
-              <Tooltip
-                text={openingHoursTooltip(opening_times, lng)}
-                minWidth={currentLng === 'cy' ? '275px' : '230px'}
-                margin={{ left: '5px' }}
-              />
-            </Info>
-          )}
+          {opening_times &&
+            (week_days.opens || saturdays.opens || sundays.opens) && (
+              <Info margin={{ top: '5px' }}>
+                {lng.openingTimes.title}
+                <Tooltip
+                  text={openingHoursTooltip(opening_times, lng)}
+                  minWidth={currentLng === 'cy' ? '275px' : '230px'}
+                  margin={{ left: '5px' }}
+                />
+              </Info>
+            )}
         </CardCol>
         {/** Right Column */}
         <CardCol sizes={{ xs: 12, sm: 9 }}>
+          {!overview && <Info>{lng.moreInfo.noInfo}</Info>}
           {/** Medical Conditions Cover */}
           {medical_conditions_cover && (
             <Info>
@@ -167,7 +174,11 @@ const CompanyCard = ({
             <Info>
               <InfoTitle>{`${lng.moreInfo.medicalEquipmentCover.title} - `}</InfoTitle>
               {medical_equipment_cover.offers_cover
-                ? `${lng.moreInfo.medicalEquipmentCover.offered}${medical_equipment_cover.cover_amount}`
+                ? `${
+                    lng.moreInfo.medicalEquipmentCover.offered
+                  }${medical_equipment_cover.cover_amount
+                    .toString()
+                    .replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')}`
                 : `${lng.moreInfo.medicalEquipmentCover.notOffered}`}
             </Info>
           )}
@@ -198,7 +209,7 @@ const CompanyCard = ({
         </CardCol>
       </CardRow>
     </CardContainer>
-  )
+  ) : null
 }
 
 // Documentation

--- a/src/components/CompanyCard/locale_cy.json
+++ b/src/components/CompanyCard/locale_cy.json
@@ -36,7 +36,7 @@
     },
     "coronavirusCancellationCover": {
       "title": "Yswiriant Coronafirws os bydd y daith yn cael ei chanslo",
-      "tooltip": "Ni fydd pob polisi yn darparu yswiriant canslo os yw'r canslo'n gysylltiedig â Coronavirus, ond bydd rhai yn gwneud hynny. Hyd yn oed os yw'r gorchudd hwn wedi'i gynnwys, gwiriwch y telerau ac amodau sy'n ymwneud â chanslo yn ofalus cyn i chi brynu."
+      "tooltip": "Ni fydd pob polisi yn darparu yswiriant canslo os yw'r canslo'n gysylltiedig â Coronavirus, ond bydd rhai yn gwneud hynny.\nDylai cwmnïau sydd wedi ateb 'ydw' i'r cwestiwn hwn gynnig yswiriant p'un a oes gennych y firws eich hun ai peidio neu a oes rhaid i chi hunan-ynysu oherwydd eich bod wedi bod mewn cysylltiad â rhywun arall sydd â'r firws.\nHyd yn oed os yw'r gorchudd hwn wedi'i gynnwys, gwiriwch y telerau ac amodau sy'n ymwneud â chanslo yn ofalus cyn i chi brynu."
     },
     "medicalEquipmentCover": {
       "title": "Gorchudd offer meddygol",

--- a/src/components/CompanyCard/locale_cy.json
+++ b/src/components/CompanyCard/locale_cy.json
@@ -1,5 +1,9 @@
 {
+  "company": {
+    "noInfo": "Gwall: nid yw teitl y cwmni ar gael"
+  },
   "getInTouch": {
+    "noInfo": "Nid oes unrhyw wybodaeth gyswllt ar gael.",
     "website": "Gwefan",
     "email": "E-bost"
   },
@@ -11,6 +15,7 @@
     "to": "i"
   },
   "moreInfo": {
+    "noInfo": "Nid oes mwy o wybodaeth ar gael i'w harddangos.",
     "yes": "Ie",
     "no": "Na",
     "medicalCondition": {

--- a/src/components/CompanyCard/locale_cy.json
+++ b/src/components/CompanyCard/locale_cy.json
@@ -9,7 +9,7 @@
   },
   "openingTimes": {
     "title": "Oriau agor",
-    "weekdays": "Dydd Llun i Ddydd Gwener",
+    "weekdays": "Dyddiau'r Wythnos",
     "saturday": "Dydd Sadwrn",
     "sunday": "Dydd Sul",
     "to": "i"

--- a/src/components/CompanyCard/locale_en.json
+++ b/src/components/CompanyCard/locale_en.json
@@ -1,5 +1,9 @@
 {
+  "company": {
+    "noInfo": "Error: company title not available"
+  },
   "getInTouch": {
+    "noInfo": "No contact information available.",
     "website": "Website",
     "email": "Email"
   },
@@ -11,6 +15,7 @@
     "to": "to"
   },
   "moreInfo": {
+    "noInfo": "No more information available to display.",
     "yes": "Yes",
     "no": "No",
     "medicalCondition": {

--- a/src/components/CompanyCard/locale_en.json
+++ b/src/components/CompanyCard/locale_en.json
@@ -36,7 +36,7 @@
     },
     "coronavirusCancellationCover": {
       "title": "Coronavirus cover if trip cancelled",
-      "tooltip": "Not all policies will provide cancellation cover if the cancellation is linked to Coronavirus, but some will. Even if this cover is included, check the terms and conditions relating to cancellation carefully before you buy."
+      "tooltip": "Not all policies will provide cancellation cover if the cancellation is linked to Coronavirus, but some will.\nFirms that have answered 'yes' to this question should offer cover whether or not you have the virus yourself or you have to self-isolate because you have been in contact with someone else who has the virus.\nEven if this cover is included, check the terms and conditions relating to cancellation carefully before you buy."
     },
     "medicalEquipmentCover": {
       "title": "Medical equipment cover",

--- a/src/components/CompanyCard/locale_en.json
+++ b/src/components/CompanyCard/locale_en.json
@@ -9,7 +9,7 @@
   },
   "openingTimes": {
     "title": "Opening hours",
-    "weekdays": "Monday to Friday",
+    "weekdays": "Weekdays",
     "saturday": "Saturday",
     "sunday": "Sunday",
     "to": "to"

--- a/src/components/Grid/Row/index.js
+++ b/src/components/Grid/Row/index.js
@@ -25,10 +25,13 @@ function Row({
 }) {
   const renderChildren = (children, noGutter) => {
     //The <Row/> renders it's children, but passes in this.props.noGutter to each child
-    return React.Children.map(children, child =>
-      React.cloneElement(child, {
-        noGutter: noGutter,
-      })
+    return React.Children.map(
+      children,
+      child =>
+        child &&
+        React.cloneElement(child, {
+          noGutter: noGutter,
+        })
     )
   }
 

--- a/src/components/NotFound/NotFound.md
+++ b/src/components/NotFound/NotFound.md
@@ -1,7 +1,19 @@
-Renders  information
+Renders information and useful links when pages are not found.
 
 ```jsx
-import { NotFound } from '@moneypensionservice/directories';
+import React, { useState } from 'react';
+import { Row, Button, NotFound } from '@moneypensionservice/directories';
 
-<NotFound />
+const [locale, setLocale] = useState('en');
+
+<>
+<Row margin={{bottom: '20px'}}>
+  <Button onClick={() => setLocale('en')}>English</Button>
+  <Button onClick={() => setLocale('cy')}>Welsh</Button>
+</Row>
+<Row justify="center">
+  <NotFound
+    currentLng={locale} />
+</Row>
+</>
 ```

--- a/src/components/NotFound/NotFound.md
+++ b/src/components/NotFound/NotFound.md
@@ -1,0 +1,7 @@
+Renders  information
+
+```jsx
+import { NotFound } from '@moneypensionservice/directories';
+
+<NotFound />
+```

--- a/src/components/NotFound/StyledNotFound.js
+++ b/src/components/NotFound/StyledNotFound.js
@@ -1,6 +1,22 @@
 import styled from 'styled-components'
-import { Row } from '../Grid'
+import { Row, Col } from '../Grid'
+import { Heading } from '../Heading'
 
-const StyledNotFound = styled(Row)``
+const NotFoundContainer = styled(Row)`
+  overflow: hidden;
+  min-height: 650px;
+`
 
-export default StyledNotFound
+const NotFoundSection = styled(Col)``
+
+const NotFoundHeading = styled(Heading)`
+  color: ${({ theme }) => theme.colors.notFound.heading};
+`
+const LinksHeading = styled(Heading)`
+  font-weight: 700;
+  margin: 0 0 1.5em;
+  font-size: 1.25em;
+  color: ${({ theme }) => theme.colors.notFound.linksHeading};
+`
+
+export { NotFoundContainer, NotFoundSection, NotFoundHeading, LinksHeading }

--- a/src/components/NotFound/StyledNotFound.js
+++ b/src/components/NotFound/StyledNotFound.js
@@ -1,0 +1,6 @@
+import styled from 'styled-components'
+import { Row } from '../Grid'
+
+const StyledNotFound = styled(Row)``
+
+export default StyledNotFound

--- a/src/components/NotFound/index.js
+++ b/src/components/NotFound/index.js
@@ -10,8 +10,21 @@ import {
 } from './StyledNotFound'
 import { Paragraph as P } from '../Paragraph'
 import { Anchor } from '../Anchor'
+// translations
+import LocaleEn from './locale_en.json'
+import LocaleCy from './locale_cy.json'
 
-const NotFound = ({ a11yTitle, as, ...rest }) => {
+const NotFound = ({
+  a11yTitle,
+  as,
+  children,
+  currentLng,
+  i18nLng,
+  ...rest
+}) => {
+  // locale
+  const lng = i18nLng || (currentLng === 'cy' ? LocaleCy : LocaleEn)
+
   return (
     <NotFoundContainer
       aria-label={a11yTitle}
@@ -22,23 +35,15 @@ const NotFound = ({ a11yTitle, as, ...rest }) => {
       {...rest}
     >
       <NotFoundSection grow={false}>
-        <NotFoundHeading level={1}>
-          We're sorry. We can't find that page.
-        </NotFoundHeading>
-        <P>
-          Please check the address you entered or try again later and you should
-          be able to find it.
-        </P>
+        <NotFoundHeading level={1}>{lng.heading}</NotFoundHeading>
+        <P>{lng.subHeading}</P>
       </NotFoundSection>
       <NotFoundSection grow={false}>
-        <LinksHeading level={2}>Useful links</LinksHeading>
-        <Anchor href="https://traveldirectory.moneyadviceservice.org.uk/">
-          Return to the Travel Advice Directory homepage
-        </Anchor>
-        <Anchor href="https://www.moneyadviceservice.org.uk/">
-          Go to the Money Advice Service homepage
-        </Anchor>
+        <LinksHeading level={2}>{lng.links.title}</LinksHeading>
+        <Anchor href={lng.links.link_1.url}>{lng.links.link_1.text}</Anchor>
+        <Anchor href={lng.links.link_2.url}>{lng.links.link_2.text}</Anchor>
       </NotFoundSection>
+      {children && <NotFoundSection grow={false}>{children}</NotFoundSection>}
     </NotFoundContainer>
   )
 }
@@ -47,14 +52,16 @@ const NotFound = ({ a11yTitle, as, ...rest }) => {
 NotFound.propTypes = {
   /** The DOM tag or react component to use for the element. */
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
-  /** Content inside component. */
-  children: PropTypes.node,
+  /** Current Language Value */
+  currentLng: PropTypes.oneOf(['en', 'cy']),
+  /** Alternate translations for the card. */
+  i18nLng: PropTypes.object,
   ...genericPropTypes,
 }
 
 NotFound.defaultProps = {
   as: 'section',
-  children: null,
+  currentLng: 'en',
   ...genericPropsDefaults(),
 }
 

--- a/src/components/NotFound/index.js
+++ b/src/components/NotFound/index.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
+import StyledNotFound from './StyledNotFound'
+
+const NotFound = ({ a11yTitle, as, ...rest }) => {
+  return <StyledNotFound aria-label={a11yTitle} forwardedAs={as} {...rest} />
+}
+
+// Documentation
+NotFound.propTypes = {
+  /** The DOM tag or react component to use for the element. */
+  as: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
+  /** Content inside component. */
+  children: PropTypes.node,
+  ...genericPropTypes,
+}
+
+NotFound.defaultProps = {
+  as: 'section',
+  children: null,
+  ...genericPropsDefaults(),
+}

--- a/src/components/NotFound/index.js
+++ b/src/components/NotFound/index.js
@@ -19,6 +19,8 @@ const NotFound = ({
   as,
   children,
   currentLng,
+  linkText,
+  LinkUrl,
   i18nLng,
   ...rest
 }) => {
@@ -40,7 +42,9 @@ const NotFound = ({
       </NotFoundSection>
       <NotFoundSection grow={false}>
         <LinksHeading level={2}>{lng.links.title}</LinksHeading>
-        <Anchor href={lng.links.link_1.url}>{lng.links.link_1.text}</Anchor>
+        <Anchor href={LinkUrl || lng.links.link_1.url}>
+          {linkText || lng.links.link_1.text}
+        </Anchor>
         <Anchor href={lng.links.link_2.url}>{lng.links.link_2.text}</Anchor>
       </NotFoundSection>
       {children && <NotFoundSection grow={false}>{children}</NotFoundSection>}
@@ -54,6 +58,10 @@ NotFound.propTypes = {
   as: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
   /** Current Language Value */
   currentLng: PropTypes.oneOf(['en', 'cy']),
+  /** Alternate text to be displayed in the directory link. */
+  linkText: PropTypes.string,
+  /** Alternate directory link url. */
+  LinkUrl: PropTypes.string,
   /** Alternate translations for the card. */
   i18nLng: PropTypes.object,
   ...genericPropTypes,

--- a/src/components/NotFound/index.js
+++ b/src/components/NotFound/index.js
@@ -1,10 +1,46 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
-import StyledNotFound from './StyledNotFound'
+// components
+import {
+  NotFoundContainer,
+  NotFoundSection,
+  NotFoundHeading,
+  LinksHeading,
+} from './StyledNotFound'
+import { Paragraph as P } from '../Paragraph'
+import { Anchor } from '../Anchor'
 
 const NotFound = ({ a11yTitle, as, ...rest }) => {
-  return <StyledNotFound aria-label={a11yTitle} forwardedAs={as} {...rest} />
+  return (
+    <NotFoundContainer
+      aria-label={a11yTitle}
+      constrained
+      direction="column"
+      forwardedAs={as}
+      justify="space-evenly"
+      {...rest}
+    >
+      <NotFoundSection grow={false}>
+        <NotFoundHeading level={1}>
+          We're sorry. We can't find that page.
+        </NotFoundHeading>
+        <P>
+          Please check the address you entered or try again later and you should
+          be able to find it.
+        </P>
+      </NotFoundSection>
+      <NotFoundSection grow={false}>
+        <LinksHeading level={2}>Useful links</LinksHeading>
+        <Anchor href="https://traveldirectory.moneyadviceservice.org.uk/">
+          Return to the Travel Advice Directory homepage
+        </Anchor>
+        <Anchor href="https://www.moneyadviceservice.org.uk/">
+          Go to the Money Advice Service homepage
+        </Anchor>
+      </NotFoundSection>
+    </NotFoundContainer>
+  )
 }
 
 // Documentation
@@ -21,3 +57,6 @@ NotFound.defaultProps = {
   children: null,
   ...genericPropsDefaults(),
 }
+
+/** @component */
+export { NotFound }

--- a/src/components/NotFound/locale_cy.json
+++ b/src/components/NotFound/locale_cy.json
@@ -1,0 +1,15 @@
+{
+  "heading": "Mae'n ddrwg gennym. Ni allwn ddod o hyd i'r dudalen honno.",
+  "subHeading": "Gwiriwch y cyfeiriad y gwnaethoch ei nodi neu ceisiwch eto yn nes ymlaen a dylech allu dod o hyd iddo.",
+  "links": {
+    "title": "Dolenni defnyddiol",
+    "link_1": {
+      "text": "Dychwelwch i hafan y Cyfeiriadur Cyngor Teithio",
+      "url": "https://traveldirectory.moneyadviceservice.org.uk/cy"
+    },
+    "link_2": {
+      "text": "Ewch i hafan y Gwasanaeth Cyngor Arian",
+      "url": "https://www.moneyadviceservice.org.uk/cy"
+    }
+  }
+}

--- a/src/components/NotFound/locale_en.json
+++ b/src/components/NotFound/locale_en.json
@@ -1,0 +1,15 @@
+{
+  "heading": "We're sorry. We can't find that page.",
+  "subHeading": "Please check the address you entered or try again later and you should be able to find it.",
+  "links": {
+    "title": "Useful links",
+    "link_1": {
+      "text": "Return to the Travel Advice Directory homepage",
+      "url": "https://traveldirectory.moneyadviceservice.org.uk/en"
+    },
+    "link_2": {
+      "text": "Go to the Money Advice Service homepage",
+      "url": "https://www.moneyadviceservice.org.uk/en"
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export { Formfield } from './components/Formfield'
 export { Radio } from './components/Radio'
 export { Select } from './components/Select'
 // layout
+export { NotFound } from './components/NotFound'
 export { CompanyCard } from './components/CompanyCard'
 export { Footer } from './components/Footer'
 export { Header } from './components/Header'

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -75,6 +75,10 @@ export default function() {
     infotable: {
       default: '#24afa8',
     },
+    notFound: {
+      heading: masGreen,
+      linksHeading: '#2e3030',
+    },
     tooltip: {
       borderColor: '#007eae',
       fontColor: '#515151',

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -93,6 +93,7 @@ module.exports = {
             './src/components/Footer/index.js',
             './src/components/Header/index.js',
             './src/components/InfoTable/index.js',
+            './src/components/NotFound/index.js',
           ],
         },
         {


### PR DESCRIPTION
[TP11752](https://maps.tpondemand.com/entity/11752-404-component)

This PR implements the new `NotFound` component to be used in 404 pages, this component also supports alternate translations to Welsh.

Due to time constraints, as an additional piece of work to this PR, some more conditionals and fallbacks were implemented to the `CompanyCard` component in order to support different outcomes from the `data` prop fed to the component. Some tooltip text corrections requested were also made here.

Package was bumped to `1.8.5`.