### PR TITLE
11653 - Webchat Footer Button Logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneypensionservice/directories",
-  "version": "1.8.3",
+  "version": "1.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3183,6 +3183,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -6709,8 +6717,7 @@
     "follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
-      "dev": true
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.8.4",
+    "axios": "^0.20.0",
     "regenerator-runtime": "^0.13.5",
     "styled-components": "^4.4.1"
   },

--- a/src/components/Footer/ContactPanels/index.js
+++ b/src/components/Footer/ContactPanels/index.js
@@ -69,14 +69,7 @@ const ContactPanels = () => {
             {webchat.text_2}
           </Paragraph>
           <Paragraph textSize="16px">{webchat.text_3}</Paragraph>
-          <WebchatButton
-            text={
-              open
-                ? webchat.button_text.available
-                : webchat.button_text.unavailable
-            }
-            open={open}
-          />
+          <WebchatButton locale={webchat} open={open} />
           <Paragraph margin="12px 0" textSize="16px">
             {webchat.long_wait}
           </Paragraph>

--- a/src/components/Footer/ContactPanels/index.js
+++ b/src/components/Footer/ContactPanels/index.js
@@ -15,6 +15,7 @@ import {
   PhoneNumber,
 } from './StyledContactPanels'
 // components
+import WebchatButton from './webchat'
 import { Heading } from '../../Heading'
 import { Paragraph } from '../../Paragraph'
 // context
@@ -68,15 +69,13 @@ const ContactPanels = () => {
             {webchat.text_2}
           </Paragraph>
           <Paragraph textSize="16px">{webchat.text_3}</Paragraph>
-          <FooterButtons
+          <WebchatButton
             text={
               open
                 ? webchat.button_text.available
                 : webchat.button_text.unavailable
             }
-            alignSelf="center"
-            weight={400}
-            disabled={!open}
+            open={open}
           />
           <Paragraph margin="12px 0" textSize="16px">
             {webchat.long_wait}

--- a/src/components/Footer/ContactPanels/index.js
+++ b/src/components/Footer/ContactPanels/index.js
@@ -70,9 +70,11 @@ const ContactPanels = () => {
           </Paragraph>
           <Paragraph textSize="16px">{webchat.text_3}</Paragraph>
           <WebchatButton locale={webchat} open={open} />
-          <Paragraph margin="12px 0" textSize="16px">
-            {webchat.long_wait}
-          </Paragraph>
+          {open && (
+            <Paragraph margin="12px 0" textSize="16px">
+              {webchat.long_wait}
+            </Paragraph>
+          )}
         </ContactPanelColumn>
       </ContactPanelContainer>
 

--- a/src/components/Footer/ContactPanels/webchat.js
+++ b/src/components/Footer/ContactPanels/webchat.js
@@ -3,7 +3,7 @@ import axios from 'axios'
 import Button from '../../Button'
 
 const WebchatButton = ({ locale, open }) => {
-  const [busy, setBusy] = useState(true)
+  const [busy, setBusy] = useState(false)
 
   let timestamp = new Date().getTime()
 
@@ -19,6 +19,7 @@ const WebchatButton = ({ locale, open }) => {
       headers: {
         'Access-Control-Allow-Origin': '*',
         'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE,PATCH,OPTIONS',
+        'X-Requested-With': 'XMLHttpRequest',
       },
       responseType: 'arraybuffer',
       timeout: 10000,
@@ -39,7 +40,7 @@ const WebchatButton = ({ locale, open }) => {
       .then(imageData => {
         // get image width from response and set busy state
         const i = new Image()
-        i.onload = () => (i.width = 170 && setBusy(false))
+        i.onload = () => i.width < 170 && setBusy(true)
         // live chat img dimensions: 170, 46
         i.src = imageData
       })

--- a/src/components/Footer/ContactPanels/webchat.js
+++ b/src/components/Footer/ContactPanels/webchat.js
@@ -2,30 +2,67 @@ import React, { useState, useEffect } from 'react'
 import axios from 'axios'
 import Button from '../../Button'
 
-// https://webchat.moneyadviceservice.org.uk/stat.gif?u=541-1571918368140&d=www.moneyadviceservice.org.uk&p=%27https%3A//www.moneyadviceservice.org.uk/en%27&r=%27%27&response=g&timestamp=1601280051414
-
-const WebchatButton = ({ text, open }) => {
+const WebchatButton = ({ locale, open }) => {
   const [busy, setBusy] = useState(true)
 
-  const url = `https://webchat.moneyadviceservice.org.uk/newchat/chat.aspx?domain=www.moneyadviceservice.org.uk`
+  let timestamp = new Date().getTime()
+
+  // prettier-ignore
+  const requestUrl = `https://cors-anywhere.herokuapp.com/https://webchat.moneyadviceservice.org.uk/stat.gif?u=${parseInt(Math.random() * 1000)}-${timestamp}&d=www.moneyadviceservice.org.uk&timestamp=${timestamp}`
+
+  const webchatUrl = `https://webchat.moneyadviceservice.org.uk/newchat/chat.aspx?domain=www.moneyadviceservice.org.uk&timestamp=${timestamp}`
 
   useEffect(() => {
-    const imgUrl = `https://webchat.moneyadviceservice.org.uk/stat.gif?d=www.moneyadviceservice.org.uk`
-
     axios({
       method: 'get',
-      url: imgUrl,
-    }).then(response => console.log(response))
+      url: requestUrl,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE,PATCH,OPTIONS',
+      },
+      responseType: 'arraybuffer',
+      timeout: 10000,
+    })
+      .then(({ data }) => {
+        // create base64 image from arraybuffer response
+        let b64encoded = btoa(
+          [].reduce.call(
+            new Uint8Array(data),
+            function(p, c) {
+              return p + String.fromCharCode(c)
+            },
+            ''
+          )
+        )
+        return `data:image/png;base64,${b64encoded}`
+      })
+      .then(imageData => {
+        // get image width from response and set busy state
+        const i = new Image()
+        i.onload = function() {
+          console.log(i.width + ', ' + i.height)
+          // 170, 46
+          setBusy(false)
+        }
+        i.src = imageData
+      })
+      .catch(error => {
+        console.warn(error)
+      })
   }, [])
 
   return (
     <Button
-      href={open && !busy ? url : undefined}
+      href={open && !busy ? webchatUrl : undefined}
       target="_blank"
-      text={text}
       alignSelf="center"
       weight={400}
       disabled={!open || busy}
+      text={
+        open && !busy
+          ? locale.button_text.available
+          : locale.button_text.unavailable
+      }
     />
   )
 }

--- a/src/components/Footer/ContactPanels/webchat.js
+++ b/src/components/Footer/ContactPanels/webchat.js
@@ -39,11 +39,8 @@ const WebchatButton = ({ locale, open }) => {
       .then(imageData => {
         // get image width from response and set busy state
         const i = new Image()
-        i.onload = function() {
-          console.log(i.width + ', ' + i.height)
-          // 170, 46
-          setBusy(false)
-        }
+        i.onload = () => (i.width = 170 && setBusy(false))
+        // live chat img dimensions: 170, 46
         i.src = imageData
       })
       .catch(error => {

--- a/src/components/Footer/ContactPanels/webchat.js
+++ b/src/components/Footer/ContactPanels/webchat.js
@@ -8,22 +8,12 @@ const WebchatButton = ({ locale, open }) => {
   let timestamp = new Date().getTime()
 
   // prettier-ignore
-  const requestUrl = `https://cors-anywhere.herokuapp.com/https://webchat.moneyadviceservice.org.uk/stat.gif?u=${parseInt(Math.random() * 1000)}-${timestamp}&d=www.moneyadviceservice.org.uk&timestamp=${timestamp}`
+  const requestUrl = `https://webchat.moneyadviceservice.org.uk/stat.gif?u=${parseInt(Math.random() * 1000)}-${timestamp}&d=www.moneyadviceservice.org.uk&timestamp=${timestamp}`
 
   const webchatUrl = `https://webchat.moneyadviceservice.org.uk/newchat/chat.aspx?domain=www.moneyadviceservice.org.uk&timestamp=${timestamp}`
 
   useEffect(() => {
-    axios({
-      method: 'get',
-      url: requestUrl,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET,PUT,POST,DELETE,PATCH,OPTIONS',
-        'X-Requested-With': 'XMLHttpRequest',
-      },
-      responseType: 'arraybuffer',
-      timeout: 10000,
-    })
+    axios(requestUrl)
       .then(({ data }) => {
         // create base64 image from arraybuffer response
         let b64encoded = btoa(

--- a/src/components/Footer/ContactPanels/webchat.js
+++ b/src/components/Footer/ContactPanels/webchat.js
@@ -1,0 +1,33 @@
+import React, { useState, useEffect } from 'react'
+import axios from 'axios'
+import Button from '../../Button'
+
+// https://webchat.moneyadviceservice.org.uk/stat.gif?u=541-1571918368140&d=www.moneyadviceservice.org.uk&p=%27https%3A//www.moneyadviceservice.org.uk/en%27&r=%27%27&response=g&timestamp=1601280051414
+
+const WebchatButton = ({ text, open }) => {
+  const [busy, setBusy] = useState(true)
+
+  const url = `https://webchat.moneyadviceservice.org.uk/newchat/chat.aspx?domain=www.moneyadviceservice.org.uk`
+
+  useEffect(() => {
+    const imgUrl = `https://webchat.moneyadviceservice.org.uk/stat.gif?d=www.moneyadviceservice.org.uk`
+
+    axios({
+      method: 'get',
+      url: imgUrl,
+    }).then(response => console.log(response))
+  }, [])
+
+  return (
+    <Button
+      href={open && !busy ? url : undefined}
+      target="_blank"
+      text={text}
+      alignSelf="center"
+      weight={400}
+      disabled={!open || busy}
+    />
+  )
+}
+
+export default WebchatButton


### PR DESCRIPTION
[TP11653](https://maps.tpondemand.com/entity/11653-webchat-footer-button-logic)

Trying to simplify my findings from [TP11209](https://maps.tpondemand.com/entity/11209-spike-implementing-webchat-component-1-day), in this PR the webchat button logic gets implemented. 

To achieve this, a request is sent to the webchat url with the MAS referral and a timestamp which is a much simplified version of the existing on on `frontend` and returns one of two images. From the image in the response, a base64 image is initiated and depending on its width we can then check if the webchat is busy or not.

**Note:** This is a much simpler version of what exists in [frontend's webchat.js](https://github.com/moneyadviceservice/frontend/blob/master/vendor/assets/javascripts/webchat.js) and I wasn't able to actually test the busy state since I'm not really sure on how to go about in emulating the busy response from WhosOn.

**Note 2:** After speaking with the relevant parties, it was decided to push this to production since once these changes are there we won't have the cross domain request issue anymore, similar to what's happening with frontend and the test environments. Therefore the busy state will only work in production but the button should still have the `href` anyway.

**Note 3:** If you want to test the request then you can add the `cors-everywhere` prefix to the request url, you can look at the last commit where this is removed on `line 11`. 