### PR TITLE
11776 - CompanyCard Edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneypensionservice/directories",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "Directories React Component Library",
   "homepage": "https://moneyadviceservice.github.io/react_library/",
   "repository": {

--- a/src/components/CompanyCard/StyledCompanyCard.js
+++ b/src/components/CompanyCard/StyledCompanyCard.js
@@ -5,6 +5,7 @@ import { Heading } from '../Heading'
 import Button from '../Button'
 import { Paragraph } from '../Paragraph'
 import { Inline } from '../Inline'
+import { Anchor } from '../Anchor'
 import { resolveMedia } from '../../utils/helpers'
 
 const CardContainer = styled(Col)`
@@ -84,6 +85,11 @@ const InfoTitle = styled(Inline)`
   font-weight: 700;
 `
 
+const TooltipAnchor = styled(Anchor)`
+  font-style: italic;
+  font-size: 16px;
+`
+
 export {
   CardContainer,
   CardRow,
@@ -92,4 +98,5 @@ export {
   CardButton,
   Info,
   InfoTitle,
+  TooltipAnchor,
 }

--- a/src/components/CompanyCard/index.js
+++ b/src/components/CompanyCard/index.js
@@ -10,9 +10,11 @@ import {
   CardButton,
   Info,
   InfoTitle,
+  TooltipAnchor,
 } from './StyledCompanyCard'
 import { Tooltip } from '../Tooltip'
 import { Inline } from '../Inline'
+import { Anchor } from '../Anchor'
 // svg icons
 import PhoneIcon from '../../assets/Images/phone_volume.svg'
 import ExternalLinkIcon from '../../assets/Images/external_link.svg'
@@ -95,9 +97,9 @@ const CompanyCard = ({
           {/** Buttons */}
           {!online && <Info>{lng.getInTouch.noInfo}</Info>}
           {phone && (
-            <CardButton href={`tel:${phone.replace(/\s/g, '')}`}>
+            <CardButton href={`tel:${phone}`}>
               <PhoneIcon />
-              {phone.replace(/\s/g, '')}
+              {phone}
             </CardButton>
           )}
           {website && (
@@ -115,14 +117,15 @@ const CompanyCard = ({
           {/** Opening Times */}
           {opening_times &&
             (week_days.opens || saturdays.opens || sundays.opens) && (
-              <Info margin={{ top: '5px' }}>
-                {lng.openingTimes.title}
-                <Tooltip
-                  text={openingHoursTooltip(opening_times, lng)}
-                  minWidth={currentLng === 'cy' ? '235px' : '185px'}
-                  margin={{ left: '5px' }}
-                />
-              </Info>
+              <Tooltip
+                text={openingHoursTooltip(opening_times, lng)}
+                minWidth={currentLng === 'cy' ? '240px' : '190px'}
+                margin={{ left: '5px' }}
+              >
+                <Anchor width="auto" margin={{ top: '5px' }}>
+                  {lng.openingTimes.title}
+                </Anchor>
+              </Tooltip>
             )}
         </CardCol>
         {/** Right Column */}
@@ -134,7 +137,7 @@ const CompanyCard = ({
               <InfoTitle>{`${lng.moreInfo.medicalCondition.title} - `}</InfoTitle>
               {medical_conditions_cover.most_conditions_covered
                 ? lng.moreInfo.medicalCondition.covered
-                : `${lng.moreInfo.medicalCondition.specialised}: ${
+                : `${lng.moreInfo.medicalCondition.specialised} ${
                     lng.moreInfo.medicalCondition.options[
                       medical_conditions_cover.specialises_in
                     ]
@@ -148,10 +151,12 @@ const CompanyCard = ({
               {coronavirus_medical_expense ? lng.moreInfo.yes : lng.moreInfo.no}
               <Tooltip
                 text={lng.moreInfo.coronavirusMedicalExpense.tooltip}
-                side="left"
+                side={{ xs: 'bottom', md: 'left' }}
                 minWidth="260px"
                 margin={{ left: '5px' }}
-              />
+              >
+                <TooltipAnchor>{lng.moreInfo.info}</TooltipAnchor>
+              </Tooltip>
             </Info>
           )}
           {/** Coronavirus Cover for Cancelations */}
@@ -163,10 +168,12 @@ const CompanyCard = ({
                 : lng.moreInfo.no}
               <Tooltip
                 text={lng.moreInfo.coronavirusCancellationCover.tooltip}
-                side="left"
+                side={{ xs: 'bottom', md: 'left' }}
                 minWidth="260px"
                 margin={{ left: '5px' }}
-              />
+              >
+                <TooltipAnchor>{lng.moreInfo.info}</TooltipAnchor>
+              </Tooltip>
             </Info>
           )}
           {/** Medical Equipment Cover */}
@@ -174,11 +181,7 @@ const CompanyCard = ({
             <Info>
               <InfoTitle>{`${lng.moreInfo.medicalEquipmentCover.title} - `}</InfoTitle>
               {medical_equipment_cover.offers_cover
-                ? `${
-                    lng.moreInfo.medicalEquipmentCover.offered
-                  }${medical_equipment_cover.cover_amount
-                    .toString()
-                    .replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',')}`
+                ? `${lng.moreInfo.medicalEquipmentCover.offered} ${medical_equipment_cover.cover_amount}`
                 : `${lng.moreInfo.medicalEquipmentCover.notOffered}`}
             </Info>
           )}
@@ -200,10 +203,12 @@ const CompanyCard = ({
               }
               <Tooltip
                 text={lng.moreInfo.medicalScreening.tooltip}
-                side="left"
+                side={{ xs: 'bottom', md: 'left' }}
                 minWidth="260px"
                 margin={{ left: '5px' }}
-              />
+              >
+                <TooltipAnchor>{lng.moreInfo.info}</TooltipAnchor>
+              </Tooltip>
             </Info>
           )}
         </CardCol>

--- a/src/components/CompanyCard/index.js
+++ b/src/components/CompanyCard/index.js
@@ -181,7 +181,7 @@ const CompanyCard = ({
             <Info>
               <InfoTitle>{`${lng.moreInfo.medicalEquipmentCover.title} - `}</InfoTitle>
               {medical_equipment_cover.offers_cover
-                ? `${lng.moreInfo.medicalEquipmentCover.offered} ${medical_equipment_cover.cover_amount}`
+                ? `${lng.moreInfo.medicalEquipmentCover.offered}${medical_equipment_cover.cover_amount}`
                 : `${lng.moreInfo.medicalEquipmentCover.notOffered}`}
             </Info>
           )}

--- a/src/components/CompanyCard/locale_cy.json
+++ b/src/components/CompanyCard/locale_cy.json
@@ -41,7 +41,7 @@
     },
     "medicalEquipmentCover": {
       "title": "Gorchudd offer meddygol",
-      "offered": "Ie: hyd at £",
+      "offered": "Ie, hyd at £",
       "notOffered": "Ni chynigir gorchudd ar gyfer offer meddygol."
     },
     "cruiseCover": "Clawr mordeithio",

--- a/src/components/CompanyCard/locale_cy.json
+++ b/src/components/CompanyCard/locale_cy.json
@@ -16,18 +16,19 @@
   },
   "moreInfo": {
     "noInfo": "Nid oes mwy o wybodaeth ar gael i'w harddangos.",
+    "info": "gwybodaeth",
     "yes": "Ie",
     "no": "Na",
     "medicalCondition": {
       "title": "Cyflyrau meddygol dan sylw",
-      "covered": "Mae'r rhan fwyaf o amodau wedi'u cynnwys.",
+      "covered": "Mae'r rhan fwyaf o amodau wedi'u cynnwys",
       "specialised": "Yn arbenigo mewn",
       "options": {
-        "cancer": "Canser",
-        "heart_conditions": "Cyflyrau'r galon",
-        "strokes": "Strôc neu anhwylderau'r system nerfol ganolog",
-        "respiratory_problems": "Problemau anadlol",
-        "mental_health_conditions": "Problemau seicolegol neu iechyd meddwl"
+        "cancer": "canser",
+        "heart_conditions": "cyflyrau'r galon",
+        "strokes": "strôc neu anhwylderau'r system nerfol ganolog",
+        "respiratory_problems": "problemau anadlol",
+        "mental_health_conditions": "problemau seicolegol neu iechyd meddwl"
       }
     },
     "coronavirusMedicalExpense": {
@@ -36,11 +37,11 @@
     },
     "coronavirusCancellationCover": {
       "title": "Yswiriant Coronafirws os bydd y daith yn cael ei chanslo",
-      "tooltip": "Ni fydd pob polisi yn darparu yswiriant canslo os yw'r canslo'n gysylltiedig â Coronavirus, ond bydd rhai yn gwneud hynny.\nDylai cwmnïau sydd wedi ateb 'ydw' i'r cwestiwn hwn gynnig yswiriant p'un a oes gennych y firws eich hun ai peidio neu a oes rhaid i chi hunan-ynysu oherwydd eich bod wedi bod mewn cysylltiad â rhywun arall sydd â'r firws.\nHyd yn oed os yw'r gorchudd hwn wedi'i gynnwys, gwiriwch y telerau ac amodau sy'n ymwneud â chanslo yn ofalus cyn i chi brynu."
+      "tooltip": "Bydd rhai polisïau yn ad-dalu cost eich taith os bydd yn rhaid i chi ganslo oherwydd Coronavirus, ond YN UNIG os yw'r deiliad polisi'n profi'n bositif am Coronavirus ac yn methu â theithio.\nOs na all deiliad y polisi deithio oherwydd ei fod yn hunan-ynysu neu mewn cwarantîn, ni fydd y mwyafrif o bolisïau yn talu allan.\nGwiriwch yr holl amodau polisi gyda'ch darparwr yn ofalus cyn i chi brynu"
     },
     "medicalEquipmentCover": {
       "title": "Gorchudd offer meddygol",
-      "offered": "Ie hyd at £",
+      "offered": "Ie: hyd at £",
       "notOffered": "Ni chynigir gorchudd ar gyfer offer meddygol."
     },
     "cruiseCover": "Clawr mordeithio",
@@ -48,10 +49,10 @@
       "title": "Sgrinio meddygol",
       "tooltip": "Os ydych chi'n mynd i gael dyfynbrisiau gan wahanol ddarparwyr, ceisiwch ddefnyddio cwmnïau sy'n defnyddio gwahanol gwmnïau sgrinio meddygol. Gall hyn roi dewis ehangach i chi o bris a/neu yswiriant a gynigir. Mae mwy o wybodaeth am sgrinio meddygol yn ein Cwestiynau Cyffredin ar y sgrin flaenorol.",
       "companies": {
-        "verisik": "Verisk (sgôr Healix Risk Rating)",
-        "tamis": "Travel and Medical Insurance Services (TAMIS)",
+        "verisik": "Verisk",
+        "tamis": "Travel & Medical Ins Svcs",
         "protectif": "Protectif",
-        "inhouse": "Sgrinio meddygol yn cael ei wneud yn fewnol"
+        "inhouse": "Sgrinio meddygol yn fewnol"
       }
     }
   }

--- a/src/components/CompanyCard/locale_en.json
+++ b/src/components/CompanyCard/locale_en.json
@@ -41,7 +41,7 @@
     },
     "medicalEquipmentCover": {
       "title": "Medical equipment cover",
-      "offered": "Yes: up to £",
+      "offered": "Yes, up to £",
       "notOffered": "Cover for medical equipment not offered."
     },
     "cruiseCover": "Cruise cover",

--- a/src/components/CompanyCard/locale_en.json
+++ b/src/components/CompanyCard/locale_en.json
@@ -9,38 +9,39 @@
   },
   "openingTimes": {
     "title": "Opening hours",
-    "weekdays": "Weekdays",
+    "weekdays": "Mon - Fri",
     "saturday": "Saturday",
     "sunday": "Sunday",
     "to": "to"
   },
   "moreInfo": {
     "noInfo": "No more information available to display.",
+    "info": "info",
     "yes": "Yes",
     "no": "No",
     "medicalCondition": {
       "title": "Medical conditions covered",
-      "covered": "Most conditions covered.",
+      "covered": "Most conditions covered",
       "specialised": "Specialises in",
       "options": {
-        "cancer": "Cancer",
-        "heart_conditions": "Heart conditions",
-        "strokes": "Strokes or central nervous system disorders",
-        "respiratory_problems": "Respiratory problems",
-        "mental_health_conditions": "Psychological or mental health problems"
+        "cancer": "cancer",
+        "heart_conditions": "heart conditions",
+        "strokes": "strokes or central nervous system disorders",
+        "respiratory_problems": "respiratory problems",
+        "mental_health_conditions": "psychological or mental health problems"
       }
     },
     "coronavirusMedicalExpense": {
       "title": "Coronavirus cover for medical expenses",
-      "tooltip": "Not all policies will provide cover for medical emergencies and/or repatriation if you are affected by Coronavirus while you are on your trip,  but many will. So always check this before you buy.  Even if Coronavirus cover is included, always check exactly what is covered."
+      "tooltip": "Not all policies will provide cover for medical emergencies and/or repatriation if you are affected by Coronavirus while you are on your trip, but many will. So always check this before you buy. Even if Coronavirus cover is included, always check exactly what is covered."
     },
     "coronavirusCancellationCover": {
       "title": "Coronavirus cover if trip cancelled",
-      "tooltip": "Not all policies will provide cancellation cover if the cancellation is linked to Coronavirus, but some will.\nFirms that have answered 'yes' to this question should offer cover whether or not you have the virus yourself or you have to self-isolate because you have been in contact with someone else who has the virus.\nEven if this cover is included, check the terms and conditions relating to cancellation carefully before you buy."
+      "tooltip": "Some policies will refund the cost of your trip if you have to cancel because of Coronavirus, but ONLY if the policyholder tests positive for Coronavirus and is unable to travel.\nIf the policyholder can’t travel because they are self-isolating or in quarantine, most policies won’t pay out.\nCheck all the policy conditions with your provider carefully before you buy."
     },
     "medicalEquipmentCover": {
       "title": "Medical equipment cover",
-      "offered": "Yes up to £",
+      "offered": "Yes: up to £",
       "notOffered": "Cover for medical equipment not offered."
     },
     "cruiseCover": "Cruise cover",
@@ -48,10 +49,10 @@
       "title": "Medical screening",
       "tooltip": "If you are going to get quotes from different providers, try and use firms that use different medical screening companies. This may give you a wider choice of price and/or cover offered. There is more information on medical screening in our FAQs on the previous screen.",
       "companies": {
-        "verisik": "Verisk (formerly Healix Risk Rating)",
-        "tamis": "Travel and Medical Insurance Services (TAMIS)",
+        "verisik": "Verisk",
+        "tamis": "Travel & Medical Ins Svcs",
         "protectif": "Protectif",
-        "inhouse": "Medical screening undertaken in-house"
+        "inhouse": "Medical screening in-house"
       }
     }
   }

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -73,7 +73,7 @@ const Tip = styled.span`
   border-radius: 2px;
   font-size: 0.875rem;
   color: ${({ theme }) => theme.colors.tooltip.fontColor};
-  line-height: 1rem;
+  line-height: 1.25rem;
   white-space: pre-wrap;
   background-color: ${({ theme }) => theme.colors.tooltip.tipBackground};
   box-shadow: 0 1em 2em -0.5em rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
TP11776

This PR implements some final edits and copy changes to the `CompanyCard` component as described by the ticket.

The current `Tooltips` found on this component now wrap the anchor text instead of displaying the _i_ icon.

Also removes the regex being used previously as this is causing some functionality to break in some browsers, this needs to be re-implemented on a later ticket.