### PR TITLE
11780 - Tooltip Mobile Behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneypensionservice/directories",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "Directories React Component Library",
   "homepage": "https://moneyadviceservice.github.io/react_library/",
   "repository": {

--- a/src/assets/Images/mobile_close.svg
+++ b/src/assets/Images/mobile_close.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17.375 17.375">
+  <defs/>
+  <path fill="#565656" stroke="#4D4D4D" stroke-miterlimit="10" stroke-width="1.75" d="M1.084 1.29L16.25 16.46m0-15.17L1.084 16.46"/>
+</svg>

--- a/src/components/CompanyCard/StyledCompanyCard.js
+++ b/src/components/CompanyCard/StyledCompanyCard.js
@@ -43,7 +43,18 @@ const CardRow = styled(Row)`
   `}
 `
 
-const CardCol = styled(Col)``
+const CardCol = styled(Col)`
+  ${({ left }) =>
+    left &&
+    css`
+      ${resolveMedia.xs`
+        margin-bottom: 20px;
+      `}
+      ${resolveMedia.sm`
+        margin-bottom: 0;
+      `}
+    `}
+`
 
 const CompanyTitle = styled(Heading)`
   color: ${({ theme }) => theme.colors.companyCard.default};

--- a/src/components/CompanyCard/index.js
+++ b/src/components/CompanyCard/index.js
@@ -154,7 +154,7 @@ const CompanyCard = ({
               {coronavirus_medical_expense ? lng.moreInfo.yes : lng.moreInfo.no}
               <Tooltip
                 text={lng.moreInfo.coronavirusMedicalExpense.tooltip}
-                side={{ xs: 'bottom', md: 'left' }}
+                side="left"
                 minWidth="260px"
                 margin={{ left: '5px' }}
               >
@@ -171,7 +171,7 @@ const CompanyCard = ({
                 : lng.moreInfo.no}
               <Tooltip
                 text={lng.moreInfo.coronavirusCancellationCover.tooltip}
-                side={{ xs: 'bottom', md: 'left' }}
+                side="left"
                 minWidth="260px"
                 margin={{ left: '5px' }}
               >
@@ -206,7 +206,7 @@ const CompanyCard = ({
               }
               <Tooltip
                 text={lng.moreInfo.medicalScreening.tooltip}
-                side={{ xs: 'bottom', md: 'left' }}
+                side="left"
                 minWidth="260px"
                 margin={{ left: '5px' }}
               >

--- a/src/components/CompanyCard/index.js
+++ b/src/components/CompanyCard/index.js
@@ -80,6 +80,7 @@ const CompanyCard = ({
 
   return company || online || overview ? (
     <CardContainer aria-label={a11yTitle || company} {...rest}>
+      {/** Title Row */}
       <CardRow>
         <CardCol margin={{ bottom: '20px' }}>
           {company ? (
@@ -91,9 +92,10 @@ const CompanyCard = ({
           )}
         </CardCol>
       </CardRow>
+      {/** Content Row */}
       <CardRow>
         {/** Left Column */}
-        <CardCol sizes={{ xs: 12, sm: 3 }}>
+        <CardCol left sizes={{ xs: 12, sm: 3 }}>
           {/** Buttons */}
           {!online && <Info>{lng.getInTouch.noInfo}</Info>}
           {phone && (
@@ -121,6 +123,7 @@ const CompanyCard = ({
                 text={openingHoursTooltip(opening_times, lng)}
                 minWidth={currentLng === 'cy' ? '240px' : '190px'}
                 margin={{ left: '5px' }}
+                side="bottom"
               >
                 <Anchor width="auto" margin={{ top: '5px' }}>
                   {lng.openingTimes.title}

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -118,7 +118,7 @@ const Icon = styled(Anchor)`
 
 const TipClose = styled(Button)`
   background-color: ${({ theme }) => theme.colors.tooltip.tipBackground};
-  border: 2px solid #394752;
+  border: 2px solid ${({ theme }) => theme.colors.tooltip.closeBorder};
   width: 30px;
   height: 30px;
   border-radius: 50%;
@@ -131,7 +131,7 @@ const TipClose = styled(Button)`
 
   &:active {
     padding-top: 1px;
-    border-bottom: 2px solid #394752;
+    border-bottom: 2px solid ${({ theme }) => theme.colors.tooltip.closeBorder};
   }
 
   & svg {

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -5,6 +5,7 @@ import {
   resolveMedia,
 } from '../../utils/helpers'
 import { Anchor } from '../Anchor'
+import Button from '../Button'
 
 const StyledTooltip = styled.span`
   ${genericStyles}
@@ -115,4 +116,28 @@ const Icon = styled(Anchor)`
   }
 `
 
-export { StyledTooltip, Icon, Tip }
+const TipClose = styled(Button)`
+  background-color: ${({ theme }) => theme.colors.tooltip.tipBackground};
+  border: 2px solid #394752;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  padding: 1px;
+  /** positioning */
+  display: inline;
+  position: absolute;
+  top: -15px;
+  right: -15px;
+
+  &:active {
+    padding-top: 1px;
+    border-bottom: 2px solid #394752;
+  }
+
+  & svg {
+    width: 11px;
+    height: 11px;
+  }
+`
+
+export { StyledTooltip, Icon, Tip, TipClose }

--- a/src/components/Tooltip/StyledTooltip.js
+++ b/src/components/Tooltip/StyledTooltip.js
@@ -1,12 +1,19 @@
 import styled, { css } from 'styled-components'
-import { genericStyles, responsiveProps } from '../../utils/helpers'
+import {
+  genericStyles,
+  responsiveProps,
+  resolveMedia,
+} from '../../utils/helpers'
 import { Anchor } from '../Anchor'
 
 const StyledTooltip = styled.span`
   ${genericStyles}
   display: inline-block;
-  position: relative;
   cursor: pointer;
+
+  ${resolveMedia.sm`
+    position: relative;
+  `}
 `
 
 /** Side styles for popup */
@@ -60,14 +67,23 @@ const renderSide = sideProp => {
 }
 
 const Tip = styled.span`
-  /** conditional styles */
+  /** general positioning */
   display: block;
-  ${({ minWidth }) => responsiveProps('min-width', minWidth)}
-  /** positioning */
   position: absolute;
   z-index: 1000;
-  /** Prop-based side styles */
-  ${({ side }) => renderSide(side)}
+  /** mobile positioning */
+  left: 0;
+  right: 0;
+  max-width: ${({ minWidth }) => (minWidth === '160px' ? '400px' : minWidth)};
+  margin: auto;
+  /** prop-based side positioning */
+  ${resolveMedia.sm`
+    ${({ minWidth }) => responsiveProps('min-width', minWidth)}
+    ${({ side }) => renderSide(side)}
+    max-width: none;
+    margin: 0;
+  `}
+  /** other styles */
   padding: 10px;
   border: 2px solid ${({ theme }) => theme.colors.tooltip.borderColor};
   border-radius: 2px;

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -7,6 +7,7 @@ import MobileClose from '../../assets/Images/mobile_close.svg'
 const Tooltip = ({
   a11yTitle,
   children,
+  closeBtn,
   hover,
   minWidth,
   side,
@@ -53,9 +54,11 @@ const Tooltip = ({
       {show && (
         <Tip minWidth={minWidth} side={side}>
           {text}
-          <TipClose plain onClick={() => setShow(false)}>
-            <MobileClose />
-          </TipClose>
+          {closeBtn && (
+            <TipClose plain onClick={() => setShow(false)}>
+              <MobileClose />
+            </TipClose>
+          )}
         </Tip>
       )}
     </StyledTooltip>
@@ -66,6 +69,8 @@ const Tooltip = ({
 Tooltip.propTypes = {
   /** Content inside component. If children are available inside the tooltip component they'll work as the trigger. */
   children: PropTypes.node,
+  /** If false, the Tooltip close button will not display. */
+  closeBtn: PropTypes.bool,
   /** If enabled, the tooltip will show on hover. */
   hover: PropTypes.bool,
   /** Sets the minimum width of the tooltip. Responsive.e */
@@ -78,6 +83,7 @@ Tooltip.propTypes = {
 }
 
 Tooltip.defaultProps = {
+  closeBtn: true,
   minWidth: '160px',
   side: 'right',
   ...genericPropsDefaults(),

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -54,7 +54,7 @@ const Tooltip = ({
       {show && (
         <Tip minWidth={minWidth} side={side}>
           {text}
-          {closeBtn && (
+          {!hover && closeBtn && (
             <TipClose plain onClick={() => setShow(false)}>
               <MobileClose />
             </TipClose>

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -15,6 +15,7 @@ const Tooltip = ({
   const node = useRef()
   const [show, setShow] = useState(false)
 
+  /** Manage clicks */
   const handleClick = () => {
     if (!show) {
       setShow(true)

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,7 +1,8 @@
 import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { genericPropTypes, genericPropsDefaults } from '../../utils/prop-types'
-import { StyledTooltip, Icon, Tip } from './StyledTooltip'
+import { StyledTooltip, Icon, Tip, TipClose } from './StyledTooltip'
+import MobileClose from '../../assets/Images/mobile_close.svg'
 
 const Tooltip = ({
   a11yTitle,
@@ -52,6 +53,9 @@ const Tooltip = ({
       {show && (
         <Tip minWidth={minWidth} side={side}>
           {text}
+          <TipClose plain onClick={() => setShow(false)}>
+            <MobileClose />
+          </TipClose>
         </Tip>
       )}
     </StyledTooltip>

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -81,6 +81,7 @@ export default function() {
     },
     tooltip: {
       borderColor: '#007eae',
+      closeBorder: '#394752',
       fontColor: '#515151',
       iconColor: masGreen,
       iconBackground: '#e3fbe3',


### PR DESCRIPTION
[TP11780](https://maps.tpondemand.com/entity/11780-tad-mobile-view-adjust-tooltip-location)

To fix some issues with the Tooltip going outside the screen on smaller devices, in this PR I've implemented some similar behaviour to the MAS tooltips that in smaller screens it occupies full width, unless the `min-width` prop is specified. 

Added the close button to the top of the tooltip using the same `svg` as `frontend` and added a new `prop` to hide this button.

Also made some smaller adjustments to `CompanyCard` by adding some `margin-bottom` on the left column for mobile.

Package version bumped to `1.8.7`.