### PR TITLE
Correct InfoTable Head

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneypensionservice/directories",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Directories React Component Library",
   "homepage": "https://moneyadviceservice.github.io/react_library/",
   "repository": {

--- a/src/components/InfoTable/StyledInfoTable.js
+++ b/src/components/InfoTable/StyledInfoTable.js
@@ -23,7 +23,7 @@ const TableIcon = styled.span`
 `
 
 const TableHead = styled(Col)`
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   font-weight: 500;
   line-height: 1.4375rem;
   padding: 0.75rem;

--- a/src/components/InfoTable/index.js
+++ b/src/components/InfoTable/index.js
@@ -26,6 +26,7 @@ const InfoTable = ({
     {...rest}
   >
     <TableHead
+      forwardedAs="h3"
       direction="row"
       align="center"
       flexWrap="nowrap"


### PR DESCRIPTION
This PR corrects the `font-size` value for the `InfoTable` title in the head implemented in the previous PR.

Bumps package to `1.9.2`.