### PR TITLE
Corrects InfoTable and Anchor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneypensionservice/directories",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Directories React Component Library",
   "homepage": "https://moneyadviceservice.github.io/react_library/",
   "repository": {

--- a/src/components/Anchor/StyledAnchor.js
+++ b/src/components/Anchor/StyledAnchor.js
@@ -2,16 +2,18 @@ import styled from 'styled-components'
 import { Paragraph } from '../Paragraph'
 
 const StyledAnchor = styled(Paragraph)`
-  color: ${props => props.colorProp || props.theme.colors.anchor.default};
+  color: ${({ colorProp, theme }) => colorProp || theme.colors.anchor.default};
   text-decoration: none;
 
   &:visited {
-    color: ${props => props.colorProp || props.theme.colors.anchor.default};
+    color: ${({ colorProp, theme }) =>
+      colorProp || theme.colors.anchor.default};
   }
 
   &:hover,
   &:focus {
-    color: ${props => props.colorProp || props.theme.colors.anchor.default};
+    color: ${({ colorProp, theme }) =>
+      colorProp || theme.colors.anchor.default};
     text-decoration: underline;
   }
 
@@ -21,16 +23,15 @@ const StyledAnchor = styled(Paragraph)`
   }
 
   &:focus {
-    outline: solid 0.1875rem ${props => props.theme.colors.anchor.outline};
-    background-color: ${props => props.theme.colors.anchor.focusBg};
-    color: ${props => props.colorProp || props.theme.colors.black};
+    outline: solid 0.1875rem ${({ theme }) => theme.colors.anchor.outline};
+    background-color: ${({ theme }) => theme.colors.anchor.focusBg};
+    color: ${({ colorProp, theme }) => colorProp || theme.colors.black};
   }
 
   // Removes active link colour that is applied in Mobile Safari and adds kerning
   &[href^='tel'] {
-    color: inherit;
+    ${({ colorProp }) => !colorProp && 'color: inherit;'}
     letter-spacing: -1px;
-    text-decoration: none;
   }
 `
 

--- a/src/components/InfoTable/StyledInfoTable.js
+++ b/src/components/InfoTable/StyledInfoTable.js
@@ -26,7 +26,7 @@ const TableHead = styled(Col)`
   font-size: 1.375rem;
   font-weight: 500;
   line-height: 1.4375rem;
-  padding: 0.75rem;
+  padding: 0.75rem 1.5rem;
 
   ${({ titleColor }) =>
     css`


### PR DESCRIPTION
Adjusts `InfoTable` header `padding` to align with the content padding.

When using `tel` in the `href` property of the `Anchor` component will not modify the color anymore.

Bumps package version to `1.9.3`.