### PR TITLE
11737 - Implement Component Tests

### DIFF
--- a/src/components/Anchor/Anchor.test.js
+++ b/src/components/Anchor/Anchor.test.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { render } from '../../utils/testing'
+import { Anchor } from '../Anchor'
+
+describe('<Anchor />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot', () => {
+      const { container } = render(<Anchor>example text</Anchor>)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot with italic and textSize props', () => {
+      const { container } = render(
+        <Anchor italic textSize="12px">
+          example text
+        </Anchor>
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot with weight and underline props', () => {
+      const { container } = render(
+        <Anchor weight="700" underline>
+          example text
+        </Anchor>
+      )
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('href prop', () => {
+    it('should apply href property to the anchor', () => {
+      const { container, getByText } = render(
+        <Anchor href="https://www.test.com/">example</Anchor>
+      )
+      // snapshot with href
+      expect(container).toMatchSnapshot()
+      // href
+      expect(getByText('example').href).toBe('https://www.test.com/')
+    })
+  })
+})

--- a/src/components/Anchor/__snapshots__/Anchor.test.js.snap
+++ b/src/components/Anchor/__snapshots__/Anchor.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Anchor /> Snapshots should match snapshot 1`] = `
+<div>
+  <a
+    class="StyledParagraph-sc-1toaej-0 gpltyO StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+  >
+    example text
+  </a>
+</div>
+`;
+
+exports[`<Anchor /> Snapshots should match snapshot with italic and textSize props 1`] = `
+<div>
+  <a
+    class="StyledParagraph-sc-1toaej-0 blbiyd StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+  >
+    example text
+  </a>
+</div>
+`;
+
+exports[`<Anchor /> Snapshots should match snapshot with weight and underline props 1`] = `
+<div>
+  <a
+    class="StyledParagraph-sc-1toaej-0 koRzUD StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+  >
+    example text
+  </a>
+</div>
+`;
+
+exports[`<Anchor /> href prop should apply href property to the anchor 1`] = `
+<div>
+  <a
+    class="StyledParagraph-sc-1toaej-0 gpltyO StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+    href="https://www.test.com/"
+  >
+    example
+  </a>
+</div>
+`;

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -1,44 +1,51 @@
-import { render, waitForElement } from '@testing-library/react'
 import React from 'react'
-import ThemeProvider from '../ThemeProvider'
-import theme from '../../theme'
-import Button from './index'
+import { render, fireEvent } from '../../utils/testing'
+import Button from '../Button'
 
-// Hoist helper functions (but not vars) to reuse between test cases
-const renderComponent = ({ theme, text }) =>
-  render(
-    <ThemeProvider theme={theme}>
-      <Button text={text} />
-    </ThemeProvider>
-  )
+describe('<Button />', () => {
+  describe('Snapshots', () => {
+    it('should match default snapshot', () => {
+      const { container } = render(<Button />)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match default disabled snapshot', () => {
+      const { container } = render(<Button disabled />)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match primary snapshot', () => {
+      const { container } = render(<Button primary />)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match primary disabled snapshot', () => {
+      const { container } = render(<Button primary disabled />)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match blog snapshot', () => {
+      const { container } = render(<Button blog />)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match plain snapshot', () => {
+      const { container } = render(<Button plain />)
+      expect(container).toMatchSnapshot()
+    })
+  })
 
-it('renders button text', async () => {
-  // Render new instance in every test to prevent leaking state
-  const { getByText } = renderComponent({ theme: theme, text: 'We Salute You' })
+  describe('text prop', () => {
+    it('should display value as Button children', () => {
+      const { container } = render(<Button text="Cancel" />)
 
-  await waitForElement(() => getByText(/We Salute You/i))
-})
+      expect(container.querySelector('button').textContent).toBe('Cancel')
+    })
+  })
 
-/**
- * 
- describe('Button', () => {
-  test('should display text', () => {
-    const { container } = render(<Button text="We Salute You!" />)
+  describe('onClick prop', () => {
+    it('should call onClick function when Button is clicked', () => {
+      const onClickMock = jest.fn()
+      const { getByText } = render(<Button onClick={onClickMock} text="ok" />)
 
-    getByText(container, 'We Salute You!')
+      fireEvent.click(getByText('ok'))
+
+      expect(onClickMock).toHaveBeenCalled()
+    })
   })
 })
-
-describe("Button", () => {
-  test("should handle click events", () => {
-    const onClickMock = jest.fn();
-    const { container } = render(
-      <Button text="Click me, maybe?" onClick={onClickMock} />
-    );
-    const component = container.firstChild;
-
-    fireEvent.click(component);
-
-    expect(onClickMock).toBeCalled();
-});
-*/

--- a/src/components/Button/Button.test.js
+++ b/src/components/Button/Button.test.js
@@ -45,7 +45,7 @@ describe('<Button />', () => {
 
       fireEvent.click(getByText('ok'))
 
-      expect(onClickMock).toHaveBeenCalled()
+      expect(onClickMock).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Button/__snapshots__/Button.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<Button /> Snapshots should match blog snapshot 1`] = `
 <div>
   <button
-    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 bzIoiq"
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 hrYGQy"
     type="button"
   />
 </div>
@@ -12,7 +12,7 @@ exports[`<Button /> Snapshots should match blog snapshot 1`] = `
 exports[`<Button /> Snapshots should match default disabled snapshot 1`] = `
 <div>
   <button
-    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 kazNJP"
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 cEHaJL"
     disabled=""
     type="button"
   />
@@ -22,7 +22,7 @@ exports[`<Button /> Snapshots should match default disabled snapshot 1`] = `
 exports[`<Button /> Snapshots should match default snapshot 1`] = `
 <div>
   <button
-    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 kazNJP"
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 cEHaJL"
     type="button"
   />
 </div>
@@ -31,7 +31,7 @@ exports[`<Button /> Snapshots should match default snapshot 1`] = `
 exports[`<Button /> Snapshots should match plain snapshot 1`] = `
 <div>
   <button
-    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 bIrchm"
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 dBANDC"
     type="button"
   />
 </div>
@@ -40,7 +40,7 @@ exports[`<Button /> Snapshots should match plain snapshot 1`] = `
 exports[`<Button /> Snapshots should match primary disabled snapshot 1`] = `
 <div>
   <button
-    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 bpPjnY"
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 gxEGFn"
     disabled=""
     type="button"
   />
@@ -50,7 +50,7 @@ exports[`<Button /> Snapshots should match primary disabled snapshot 1`] = `
 exports[`<Button /> Snapshots should match primary snapshot 1`] = `
 <div>
   <button
-    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 bpPjnY"
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 gxEGFn"
     type="button"
   />
 </div>

--- a/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/src/components/Button/__snapshots__/Button.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Button /> Snapshots should match blog snapshot 1`] = `
+<div>
+  <button
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 bzIoiq"
+    type="button"
+  />
+</div>
+`;
+
+exports[`<Button /> Snapshots should match default disabled snapshot 1`] = `
+<div>
+  <button
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 kazNJP"
+    disabled=""
+    type="button"
+  />
+</div>
+`;
+
+exports[`<Button /> Snapshots should match default snapshot 1`] = `
+<div>
+  <button
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 kazNJP"
+    type="button"
+  />
+</div>
+`;
+
+exports[`<Button /> Snapshots should match plain snapshot 1`] = `
+<div>
+  <button
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 bIrchm"
+    type="button"
+  />
+</div>
+`;
+
+exports[`<Button /> Snapshots should match primary disabled snapshot 1`] = `
+<div>
+  <button
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 bpPjnY"
+    disabled=""
+    type="button"
+  />
+</div>
+`;
+
+exports[`<Button /> Snapshots should match primary snapshot 1`] = `
+<div>
+  <button
+    class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 bpPjnY"
+    type="button"
+  />
+</div>
+`;

--- a/src/components/Checkbox/Checkbox.test.js
+++ b/src/components/Checkbox/Checkbox.test.js
@@ -59,7 +59,7 @@ describe('<Checkbox />', () => {
 
       fireEvent.click(getByTestId('checkbox'))
 
-      expect(onChangeMock).toHaveBeenCalled()
+      expect(onChangeMock).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/components/Checkbox/Checkbox.test.js
+++ b/src/components/Checkbox/Checkbox.test.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import { render, fireEvent } from '../../utils/testing'
+import { Checkbox } from '../Checkbox'
+
+describe('<Checkbox />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot without props', () => {
+      const { container } = render(<Checkbox />)
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot with disabled prop', () => {
+      const { container } = render(<Checkbox disabled />)
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('Checkbox label', () => {
+    const label = 'label text'
+
+    it('should display label prop as Checkbox label', () => {
+      const { container } = render(<Checkbox label={label} />)
+
+      expect(container.querySelector('label').textContent).toBe(label)
+    })
+
+    it('should display children as Checkbox label', () => {
+      const { container } = render(<Checkbox>{label}</Checkbox>)
+
+      expect(container.querySelector('label').textContent).toBe(label)
+    })
+
+    it('should apply given color to the label', () => {
+      const { container } = render(<Checkbox style={{ color: 'red' }} />)
+      expect(container.querySelector('label').style.color).toBe('red')
+    })
+  })
+
+  describe('Checked status', () => {
+    it('should changed the checked status of the input when the label is clicked', () => {
+      const { container, getByTestId } = render(
+        <Checkbox label="text" data-testid="checkbox" />
+      )
+
+      expect(container.querySelector('input').checked).toEqual(false)
+
+      fireEvent.click(getByTestId('checkbox'))
+
+      expect(container.querySelector('input').checked).toEqual(true)
+    })
+  })
+
+  describe('onChange prop', () => {
+    it('should call onChange function when Checkbox is changed', () => {
+      const onChangeMock = jest.fn()
+      const { getByTestId } = render(
+        <Checkbox onChange={onChangeMock} label="text" data-testid="checkbox" />
+      )
+
+      fireEvent.click(getByTestId('checkbox'))
+
+      expect(onChangeMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('value prop', () => {
+    it('should apply the value property', () => {
+      const { container } = render(<Checkbox value="my value" />)
+
+      expect(container.querySelector('input').value).toBe('my value')
+    })
+  })
+
+  describe('name prop', () => {
+    it('should apply the name property', () => {
+      const { container } = render(<Checkbox name="my name" />)
+
+      expect(container.querySelector('input').name).toBe('my name')
+    })
+  })
+})

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Checkbox /> Snapshots should match snapshot with disabled prop 1`] = `
+<div>
+  <label
+    class="StyledCheckbox__Label-sc-1atc3e8-0 fsfXDH"
+    disabled=""
+  >
+    <input
+      aria-required="false"
+      class="StyledCheckbox__Field-sc-1atc3e8-1 jaeJwW"
+      disabled=""
+      type="checkbox"
+      value=""
+    />
+  </label>
+</div>
+`;
+
+exports[`<Checkbox /> Snapshots should match snapshot without props 1`] = `
+<div>
+  <label
+    class="StyledCheckbox__Label-sc-1atc3e8-0 bVAspM"
+  >
+    <input
+      aria-required="false"
+      class="StyledCheckbox__Field-sc-1atc3e8-1 jaeJwW"
+      type="checkbox"
+      value=""
+    />
+  </label>
+</div>
+`;

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.js.snap
@@ -3,12 +3,12 @@
 exports[`<Checkbox /> Snapshots should match snapshot with disabled prop 1`] = `
 <div>
   <label
-    class="StyledCheckbox__Label-sc-1atc3e8-0 fsfXDH"
+    class="StyledCheckbox__Label-sc-1atc3e8-0 dZCEwt"
     disabled=""
   >
     <input
       aria-required="false"
-      class="StyledCheckbox__Field-sc-1atc3e8-1 jaeJwW"
+      class="StyledCheckbox__Field-sc-1atc3e8-1 ggmXuk"
       disabled=""
       type="checkbox"
       value=""
@@ -20,11 +20,11 @@ exports[`<Checkbox /> Snapshots should match snapshot with disabled prop 1`] = `
 exports[`<Checkbox /> Snapshots should match snapshot without props 1`] = `
 <div>
   <label
-    class="StyledCheckbox__Label-sc-1atc3e8-0 bVAspM"
+    class="StyledCheckbox__Label-sc-1atc3e8-0 hGMOrn"
   >
     <input
       aria-required="false"
-      class="StyledCheckbox__Field-sc-1atc3e8-1 jaeJwW"
+      class="StyledCheckbox__Field-sc-1atc3e8-1 ggmXuk"
       type="checkbox"
       value=""
     />

--- a/src/components/Form/Form.test.js
+++ b/src/components/Form/Form.test.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from '../../utils/testing'
+import { Form } from '../Form'
+
+describe('<Form />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot with children element', () => {
+      const { container } = render(
+        <Form>
+          <p>example child</p>
+        </Form>
+      )
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/Form/__snapshots__/Form.test.js.snap
+++ b/src/components/Form/__snapshots__/Form.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Form /> Snapshots should match snapshot with children element 1`] = `
+<div>
+  <form
+    class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledForm-j6ft8m-0 hhgDcV"
+  >
+    <p>
+      example child
+    </p>
+  </form>
+</div>
+`;

--- a/src/components/Formfield/Formfield.test.js
+++ b/src/components/Formfield/Formfield.test.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render } from '../../utils/testing'
+import { Formfield } from '../Formfield'
+
+describe('<Formfield />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot with legend prop and children element', () => {
+      const { container } = render(
+        <Formfield legend="example">
+          <p>example child</p>
+        </Formfield>
+      )
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/Formfield/__snapshots__/Formfield.test.js.snap
+++ b/src/components/Formfield/__snapshots__/Formfield.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Formfield /> Snapshots should match snapshot with legend prop and children element 1`] = `
+<div>
+  <fieldset
+    class="StyledFormfield-yeky1l-0 fvMpSK"
+  >
+    <legend
+      class="StyledFormfield__Legend-yeky1l-1 haPxoA"
+    >
+      example
+    </legend>
+    <p>
+      example child
+    </p>
+  </fieldset>
+</div>
+`;

--- a/src/components/Formfield/__snapshots__/Formfield.test.js.snap
+++ b/src/components/Formfield/__snapshots__/Formfield.test.js.snap
@@ -3,10 +3,11 @@
 exports[`<Formfield /> Snapshots should match snapshot with legend prop and children element 1`] = `
 <div>
   <fieldset
-    class="StyledFormfield-yeky1l-0 fvMpSK"
+    aria-label="example"
+    class="StyledFormfield-yeky1l-0 kIEUKv"
   >
     <legend
-      class="StyledFormfield__Legend-yeky1l-1 haPxoA"
+      class="StyledFormfield__Legend-yeky1l-1 bhMqHd"
     >
       example
     </legend>

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -35,7 +35,7 @@ describe('<Header />', () => {
 
       fireEvent.click(getByTestId('localeAnchor'))
 
-      expect(onClickMock).toHaveBeenCalled()
+      expect(onClickMock).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { render, fireEvent } from '../../utils/testing'
+import { Header } from '../Header'
+
+describe('<Header />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot', () => {
+      const { container } = render(<Header />)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot in Welsh', () => {
+      const { container } = render(<Header currentLng="cy" />)
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('lngUrl prop', () => {
+    it('should change the anchor url', () => {
+      const { container, getByTestId } = render(
+        <Header lngUrl="https://www.test.com/" />
+      )
+      // snapshot
+      expect(container).toMatchSnapshot()
+      // href
+      expect(getByTestId('localeAnchor').href).toBe('https://www.test.com/')
+    })
+  })
+
+  describe('setLng prop', () => {
+    it('should call function on anchor click', () => {
+      const onClickMock = jest.fn()
+      const { container, getByTestId } = render(<Header setLng={onClickMock} />)
+      // snapshot
+      expect(container).toMatchSnapshot()
+
+      fireEvent.click(getByTestId('localeAnchor'))
+
+      expect(onClickMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/Header/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__snapshots__/Header.test.js.snap
@@ -1,0 +1,246 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Header /> Snapshots should match snapshot 1`] = `
+<div>
+  <header
+    class="styledContainer__ContainerWrapper-ux129m-0 cBvoAu StyledHeader__HeaderContainer-nhaq8b-0 kqbXpf"
+  >
+    <div
+      class="styledRow__RowWrapper-sc-1ip85in-0 XbhRj StyledHeader__MapsBannerRow-nhaq8b-4 gZEGHo"
+    >
+      <div
+        class="styledCol__ColWrapper-sc-1mivnjm-0 echTSp"
+      >
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 hwdKXn StyledHeader__MapsLogo-nhaq8b-5 jhPcbu"
+        >
+          <span
+            class="StyledHeader__MapsLogoText-nhaq8b-6 gqpbPZ"
+          >
+            <span>
+              The Money Advice
+            </span>
+            <span>
+              Service is provided by
+            </span>
+          </span>
+          <test-file-stub />
+        </div>
+      </div>
+    </div>
+    <div
+      class="styledRow__RowWrapper-sc-1ip85in-0 cYiCXW StyledHeader__HeaderRow-nhaq8b-1 bGFUQm"
+    >
+      <div
+        class="styledCol__ColWrapper-sc-1mivnjm-0 hYHTJn"
+      >
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp"
+        >
+          <a
+            aria-label="Money Advice Service"
+            class="StyledParagraph-sc-1toaej-0 cBLpIS StyledAnchor-sc-1qj1ci5-0 fNhjgf StyledHeader__LogoContainer-nhaq8b-3 jcJypd"
+            href="https://www.moneyadviceservice.org.uk/en"
+          >
+            <test-file-stub />
+          </a>
+        </div>
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp"
+        >
+          <a
+            class="StyledParagraph-sc-1toaej-0 hZKqQo StyledAnchor-sc-1qj1ci5-0 jjWyuo StyledHeader__LocaleContainer-nhaq8b-2"
+            data-testid="localeAnchor"
+          >
+            Cymraeg
+          </a>
+        </div>
+      </div>
+    </div>
+  </header>
+</div>
+`;
+
+exports[`<Header /> Snapshots should match snapshot in Welsh 1`] = `
+<div>
+  <header
+    class="styledContainer__ContainerWrapper-ux129m-0 cBvoAu StyledHeader__HeaderContainer-nhaq8b-0 kqbXpf"
+  >
+    <div
+      class="styledRow__RowWrapper-sc-1ip85in-0 XbhRj StyledHeader__MapsBannerRow-nhaq8b-4 gZEGHo"
+    >
+      <div
+        class="styledCol__ColWrapper-sc-1mivnjm-0 echTSp"
+      >
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 hwdKXn StyledHeader__MapsLogo-nhaq8b-5 jhPcbu"
+        >
+          <span
+            class="StyledHeader__MapsLogoText-nhaq8b-6 gqpbPZ"
+          >
+            <span>
+              Gwasanaeth Cynghori Ariannol
+            </span>
+            <span>
+              yn cael ei ddarparu gan
+            </span>
+          </span>
+          <test-file-stub />
+        </div>
+      </div>
+    </div>
+    <div
+      class="styledRow__RowWrapper-sc-1ip85in-0 cYiCXW StyledHeader__HeaderRow-nhaq8b-1 bGFUQm"
+    >
+      <div
+        class="styledCol__ColWrapper-sc-1mivnjm-0 hYHTJn"
+      >
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp"
+        >
+          <a
+            aria-label="Money Advice Service"
+            class="StyledParagraph-sc-1toaej-0 cBLpIS StyledAnchor-sc-1qj1ci5-0 fNhjgf StyledHeader__LogoContainer-nhaq8b-3 jcJypd"
+            href="https://www.moneyadviceservice.org.uk/en"
+          >
+            <test-file-stub />
+          </a>
+        </div>
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp"
+        >
+          <a
+            class="StyledParagraph-sc-1toaej-0 hZKqQo StyledAnchor-sc-1qj1ci5-0 jjWyuo StyledHeader__LocaleContainer-nhaq8b-2"
+            data-testid="localeAnchor"
+          >
+            English
+          </a>
+        </div>
+      </div>
+    </div>
+  </header>
+</div>
+`;
+
+exports[`<Header /> lngUrl prop should change the anchor url 1`] = `
+<div>
+  <header
+    class="styledContainer__ContainerWrapper-ux129m-0 cBvoAu StyledHeader__HeaderContainer-nhaq8b-0 kqbXpf"
+  >
+    <div
+      class="styledRow__RowWrapper-sc-1ip85in-0 XbhRj StyledHeader__MapsBannerRow-nhaq8b-4 gZEGHo"
+    >
+      <div
+        class="styledCol__ColWrapper-sc-1mivnjm-0 echTSp"
+      >
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 hwdKXn StyledHeader__MapsLogo-nhaq8b-5 jhPcbu"
+        >
+          <span
+            class="StyledHeader__MapsLogoText-nhaq8b-6 gqpbPZ"
+          >
+            <span>
+              The Money Advice
+            </span>
+            <span>
+              Service is provided by
+            </span>
+          </span>
+          <test-file-stub />
+        </div>
+      </div>
+    </div>
+    <div
+      class="styledRow__RowWrapper-sc-1ip85in-0 cYiCXW StyledHeader__HeaderRow-nhaq8b-1 bGFUQm"
+    >
+      <div
+        class="styledCol__ColWrapper-sc-1mivnjm-0 hYHTJn"
+      >
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp"
+        >
+          <a
+            aria-label="Money Advice Service"
+            class="StyledParagraph-sc-1toaej-0 cBLpIS StyledAnchor-sc-1qj1ci5-0 fNhjgf StyledHeader__LogoContainer-nhaq8b-3 jcJypd"
+            href="https://www.moneyadviceservice.org.uk/en"
+          >
+            <test-file-stub />
+          </a>
+        </div>
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp"
+        >
+          <a
+            class="StyledParagraph-sc-1toaej-0 hZKqQo StyledAnchor-sc-1qj1ci5-0 jjWyuo StyledHeader__LocaleContainer-nhaq8b-2"
+            data-testid="localeAnchor"
+            href="https://www.test.com/"
+          >
+            Cymraeg
+          </a>
+        </div>
+      </div>
+    </div>
+  </header>
+</div>
+`;
+
+exports[`<Header /> setLng prop should call function on anchor click 1`] = `
+<div>
+  <header
+    class="styledContainer__ContainerWrapper-ux129m-0 cBvoAu StyledHeader__HeaderContainer-nhaq8b-0 kqbXpf"
+  >
+    <div
+      class="styledRow__RowWrapper-sc-1ip85in-0 XbhRj StyledHeader__MapsBannerRow-nhaq8b-4 gZEGHo"
+    >
+      <div
+        class="styledCol__ColWrapper-sc-1mivnjm-0 echTSp"
+      >
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 hwdKXn StyledHeader__MapsLogo-nhaq8b-5 jhPcbu"
+        >
+          <span
+            class="StyledHeader__MapsLogoText-nhaq8b-6 gqpbPZ"
+          >
+            <span>
+              The Money Advice
+            </span>
+            <span>
+              Service is provided by
+            </span>
+          </span>
+          <test-file-stub />
+        </div>
+      </div>
+    </div>
+    <div
+      class="styledRow__RowWrapper-sc-1ip85in-0 cYiCXW StyledHeader__HeaderRow-nhaq8b-1 bGFUQm"
+    >
+      <div
+        class="styledCol__ColWrapper-sc-1mivnjm-0 hYHTJn"
+      >
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp"
+        >
+          <a
+            aria-label="Money Advice Service"
+            class="StyledParagraph-sc-1toaej-0 cBLpIS StyledAnchor-sc-1qj1ci5-0 fNhjgf StyledHeader__LogoContainer-nhaq8b-3 jcJypd"
+            href="https://www.moneyadviceservice.org.uk/en"
+          >
+            <test-file-stub />
+          </a>
+        </div>
+        <div
+          class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp"
+        >
+          <a
+            class="StyledParagraph-sc-1toaej-0 hZKqQo StyledAnchor-sc-1qj1ci5-0 jjWyuo StyledHeader__LocaleContainer-nhaq8b-2"
+            data-testid="localeAnchor"
+          >
+            Cymraeg
+          </a>
+        </div>
+      </div>
+    </div>
+  </header>
+</div>
+`;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -76,6 +76,7 @@ const Header = ({
                 margin="0"
                 onClick={setLng}
                 href={lngUrl}
+                data-testid="localeAnchor"
               >
                 {lng.localeButton}
               </LocaleContainer>

--- a/src/components/InfoTable/InfoTable.test.js
+++ b/src/components/InfoTable/InfoTable.test.js
@@ -5,18 +5,22 @@ import { InfoTable } from '../InfoTable'
 describe('<InfoTable />', () => {
   describe('Snapshots', () => {
     it('should match snapshot with title and textContent props', () => {
-      const { container } = render(
+      const { container, getByTestId } = render(
         <InfoTable title="example" textContent="example content" />
       )
+      // snapshot
       expect(container).toMatchSnapshot()
+      // content
+      expect(getByTestId('content').textContent).toBe('example content')
     })
     it('should match snapshot with title prop and children', () => {
-      const { container } = render(
-        <InfoTable title="example">
-          <p>example child</p>
-        </InfoTable>
+      const { container, getByTestId } = render(
+        <InfoTable title="example">example child</InfoTable>
       )
+      // snapshot
       expect(container).toMatchSnapshot()
+      // content
+      expect(getByTestId('content').textContent).toBe('example child')
     })
     it('should match snapshot with tableColor and titleColor props', () => {
       const { container } = render(

--- a/src/components/InfoTable/InfoTable.test.js
+++ b/src/components/InfoTable/InfoTable.test.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render } from '../../utils/testing'
+import { InfoTable } from '../InfoTable'
+
+describe('<InfoTable />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot with title and textContent props', () => {
+      const { container } = render(
+        <InfoTable title="example" textContent="example content" />
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot with title prop and children', () => {
+      const { container } = render(
+        <InfoTable title="example">
+          <p>example child</p>
+        </InfoTable>
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot with tableColor and titleColor props', () => {
+      const { container } = render(
+        <InfoTable
+          title="example"
+          textContent="example content"
+          tableColor="aqua"
+          titleColor="black"
+        />
+      )
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/InfoTable/__snapshots__/InfoTable.test.js.snap
+++ b/src/components/InfoTable/__snapshots__/InfoTable.test.js.snap
@@ -13,6 +13,7 @@ exports[`<InfoTable /> Snapshots should match snapshot with tableColor and title
     </h3>
     <div
       class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledInfoTable__TableContent-t9zemp-3 esOBTz"
+      data-testid="content"
     >
       <p
         class="StyledParagraph-sc-1toaej-0 gpltyO StyledInfoTable__TableText-t9zemp-4"
@@ -37,6 +38,7 @@ exports[`<InfoTable /> Snapshots should match snapshot with title and textConten
     </h3>
     <div
       class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledInfoTable__TableContent-t9zemp-3 esOBTz"
+      data-testid="content"
     >
       <p
         class="StyledParagraph-sc-1toaej-0 gpltyO StyledInfoTable__TableText-t9zemp-4"
@@ -61,10 +63,9 @@ exports[`<InfoTable /> Snapshots should match snapshot with title prop and child
     </h3>
     <div
       class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledInfoTable__TableContent-t9zemp-3 esOBTz"
+      data-testid="content"
     >
-      <p>
-        example child
-      </p>
+      example child
     </div>
   </div>
 </div>

--- a/src/components/InfoTable/__snapshots__/InfoTable.test.js.snap
+++ b/src/components/InfoTable/__snapshots__/InfoTable.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<InfoTable /> Snapshots should match snapshot with tableColor and titleColor props 1`] = `
+<div>
+  <div
+    aria-label="example"
+    class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledInfoTable__TableContainer-t9zemp-0 iRNxLK"
+  >
+    <h3
+      class="styledCol__ColWrapper-sc-1mivnjm-0 cJqMBd StyledInfoTable__TableHead-t9zemp-2 dWFYiL"
+    >
+      example
+    </h3>
+    <div
+      class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledInfoTable__TableContent-t9zemp-3 esOBTz"
+    >
+      <p
+        class="StyledParagraph-sc-1toaej-0 gpltyO StyledInfoTable__TableText-t9zemp-4"
+      >
+        example content
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<InfoTable /> Snapshots should match snapshot with title and textContent props 1`] = `
+<div>
+  <div
+    aria-label="example"
+    class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledInfoTable__TableContainer-t9zemp-0 egTFuN"
+  >
+    <h3
+      class="styledCol__ColWrapper-sc-1mivnjm-0 cJqMBd StyledInfoTable__TableHead-t9zemp-2 ekcFyQ"
+    >
+      example
+    </h3>
+    <div
+      class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledInfoTable__TableContent-t9zemp-3 esOBTz"
+    >
+      <p
+        class="StyledParagraph-sc-1toaej-0 gpltyO StyledInfoTable__TableText-t9zemp-4"
+      >
+        example content
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<InfoTable /> Snapshots should match snapshot with title prop and children 1`] = `
+<div>
+  <div
+    aria-label="example"
+    class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledInfoTable__TableContainer-t9zemp-0 egTFuN"
+  >
+    <h3
+      class="styledCol__ColWrapper-sc-1mivnjm-0 cJqMBd StyledInfoTable__TableHead-t9zemp-2 ekcFyQ"
+    >
+      example
+    </h3>
+    <div
+      class="styledCol__ColWrapper-sc-1mivnjm-0 fhguMU StyledInfoTable__TableContent-t9zemp-3 esOBTz"
+    >
+      <p>
+        example child
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/InfoTable/index.js
+++ b/src/components/InfoTable/index.js
@@ -36,7 +36,7 @@ const InfoTable = ({
       {icon && <TableIcon titleColor={titleColor}>{icon}</TableIcon>}
       {title}
     </TableHead>
-    <TableContent padding={padding}>
+    <TableContent padding={padding} data-testid="content">
       {textContent && <TableText>{textContent}</TableText>}
       {children}
     </TableContent>

--- a/src/components/Inline/Inline.test.js
+++ b/src/components/Inline/Inline.test.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render } from '../../utils/testing'
+import { Inline } from '../Inline'
+
+describe('<Inline />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot with children element', () => {
+      const { container } = render(<Inline>example child</Inline>)
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/Inline/__snapshots__/Inline.test.js.snap
+++ b/src/components/Inline/__snapshots__/Inline.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Inline /> Snapshots should match snapshot with children element 1`] = `
+<div>
+  <span
+    class="StyledParagraph-sc-1toaej-0 gpltyO"
+  >
+    example child
+  </span>
+</div>
+`;

--- a/src/components/NotFound/NotFound.test.js
+++ b/src/components/NotFound/NotFound.test.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { render } from '../../utils/testing'
+import { NotFound } from '../NotFound'
+
+describe('<NotFound />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot', () => {
+      const { container } = render(<NotFound />)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot in Welsh', () => {
+      const { container } = render(<NotFound currentLng="cy" />)
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('custom link props', () => {
+    it('linkText and linkUrl props', () => {
+      const { container, getByTestId } = render(
+        <NotFound linkText="customLinkText" LinkUrl="https://www.test.com/" />
+      )
+      // snapshot
+      expect(container).toMatchSnapshot()
+      // anchor text content
+      expect(getByTestId('url').textContent).toBe('customLinkText')
+      // href
+      expect(getByTestId('url').href).toBe('https://www.test.com/')
+    })
+  })
+})

--- a/src/components/NotFound/__snapshots__/NotFound.test.js.snap
+++ b/src/components/NotFound/__snapshots__/NotFound.test.js.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<NotFound /> Snapshots should match snapshot 1`] = `
+<div>
+  <section
+    class="styledRow__RowWrapper-sc-1ip85in-0 kGwesl StyledNotFound__NotFoundContainer-v06e70-0 ghBYdL"
+  >
+    <div
+      class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp StyledNotFound__NotFoundSection-v06e70-1"
+    >
+      <h1
+        class="StyledHeading-xxi4nn-0 likqsL StyledNotFound__NotFoundHeading-v06e70-2 cNoFKm"
+      >
+        We're sorry. We can't find that page.
+      </h1>
+      <p
+        class="StyledParagraph-sc-1toaej-0 gpltyO"
+      >
+        Please check the address you entered or try again later and you should be able to find it.
+      </p>
+    </div>
+    <div
+      class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp StyledNotFound__NotFoundSection-v06e70-1"
+    >
+      <h2
+        class="StyledHeading-xxi4nn-0 boqBEm StyledNotFound__LinksHeading-v06e70-3 eClJdW"
+      >
+        Useful links
+      </h2>
+      <a
+        class="StyledParagraph-sc-1toaej-0 gpltyO StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+        data-testid="url"
+        href="https://traveldirectory.moneyadviceservice.org.uk/en"
+      >
+        Return to the Travel Advice Directory homepage
+      </a>
+      <a
+        class="StyledParagraph-sc-1toaej-0 gpltyO StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+        href="https://www.moneyadviceservice.org.uk/en"
+      >
+        Go to the Money Advice Service homepage
+      </a>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`<NotFound /> Snapshots should match snapshot in Welsh 1`] = `
+<div>
+  <section
+    class="styledRow__RowWrapper-sc-1ip85in-0 kGwesl StyledNotFound__NotFoundContainer-v06e70-0 ghBYdL"
+  >
+    <div
+      class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp StyledNotFound__NotFoundSection-v06e70-1"
+    >
+      <h1
+        class="StyledHeading-xxi4nn-0 likqsL StyledNotFound__NotFoundHeading-v06e70-2 cNoFKm"
+      >
+        Mae'n ddrwg gennym. Ni allwn ddod o hyd i'r dudalen honno.
+      </h1>
+      <p
+        class="StyledParagraph-sc-1toaej-0 gpltyO"
+      >
+        Gwiriwch y cyfeiriad y gwnaethoch ei nodi neu ceisiwch eto yn nes ymlaen a dylech allu dod o hyd iddo.
+      </p>
+    </div>
+    <div
+      class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp StyledNotFound__NotFoundSection-v06e70-1"
+    >
+      <h2
+        class="StyledHeading-xxi4nn-0 boqBEm StyledNotFound__LinksHeading-v06e70-3 eClJdW"
+      >
+        Dolenni defnyddiol
+      </h2>
+      <a
+        class="StyledParagraph-sc-1toaej-0 gpltyO StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+        data-testid="url"
+        href="https://traveldirectory.moneyadviceservice.org.uk/cy"
+      >
+        Dychwelwch i hafan y Cyfeiriadur Cyngor Teithio
+      </a>
+      <a
+        class="StyledParagraph-sc-1toaej-0 gpltyO StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+        href="https://www.moneyadviceservice.org.uk/cy"
+      >
+        Ewch i hafan y Gwasanaeth Cyngor Arian
+      </a>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`<NotFound /> custom link props linkText and linkUrl props 1`] = `
+<div>
+  <section
+    class="styledRow__RowWrapper-sc-1ip85in-0 kGwesl StyledNotFound__NotFoundContainer-v06e70-0 ghBYdL"
+  >
+    <div
+      class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp StyledNotFound__NotFoundSection-v06e70-1"
+    >
+      <h1
+        class="StyledHeading-xxi4nn-0 likqsL StyledNotFound__NotFoundHeading-v06e70-2 cNoFKm"
+      >
+        We're sorry. We can't find that page.
+      </h1>
+      <p
+        class="StyledParagraph-sc-1toaej-0 gpltyO"
+      >
+        Please check the address you entered or try again later and you should be able to find it.
+      </p>
+    </div>
+    <div
+      class="styledCol__ColWrapper-sc-1mivnjm-0 kcBKMp StyledNotFound__NotFoundSection-v06e70-1"
+    >
+      <h2
+        class="StyledHeading-xxi4nn-0 boqBEm StyledNotFound__LinksHeading-v06e70-3 eClJdW"
+      >
+        Useful links
+      </h2>
+      <a
+        class="StyledParagraph-sc-1toaej-0 gpltyO StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+        data-testid="url"
+        href="https://www.test.com/"
+      >
+        customLinkText
+      </a>
+      <a
+        class="StyledParagraph-sc-1toaej-0 gpltyO StyledAnchor-sc-1qj1ci5-0 fNhjgf"
+        href="https://www.moneyadviceservice.org.uk/en"
+      >
+        Go to the Money Advice Service homepage
+      </a>
+    </div>
+  </section>
+</div>
+`;

--- a/src/components/NotFound/index.js
+++ b/src/components/NotFound/index.js
@@ -42,7 +42,7 @@ const NotFound = ({
       </NotFoundSection>
       <NotFoundSection grow={false}>
         <LinksHeading level={2}>{lng.links.title}</LinksHeading>
-        <Anchor href={LinkUrl || lng.links.link_1.url}>
+        <Anchor data-testid="url" href={LinkUrl || lng.links.link_1.url}>
           {linkText || lng.links.link_1.text}
         </Anchor>
         <Anchor href={lng.links.link_2.url}>{lng.links.link_2.text}</Anchor>

--- a/src/components/Pagination/Pagination.test.js
+++ b/src/components/Pagination/Pagination.test.js
@@ -1,0 +1,90 @@
+import React from 'react'
+import { render, fireEvent } from '../../utils/testing'
+import { Pagination } from '../Pagination'
+
+describe('<Pagination />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot', () => {
+      const { container } = render(
+        <Pagination currentPage={2} totalPages={3} />
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot in Welsh', () => {
+      const { container } = render(
+        <Pagination currentPage={2} totalPages={3} currentLng="cy" />
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot in first page', () => {
+      const { container } = render(
+        <Pagination currentPage={1} totalPages={2} />
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot in last page', () => {
+      const { container } = render(
+        <Pagination currentPage={3} totalPages={3} />
+      )
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('nextClick prop', () => {
+    it('should call nextClick function when right button is clicked', () => {
+      const nextClickMock = jest.fn()
+      const { getByTestId } = render(
+        <Pagination currentPage={2} totalPages={3} nextClick={nextClickMock} />
+      )
+
+      fireEvent.click(getByTestId('nextBtn'))
+
+      expect(nextClickMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('prevClick prop', () => {
+    it('should call prevClick function when left button is clicked', () => {
+      const prevClickMock = jest.fn()
+      const { getByTestId } = render(
+        <Pagination currentPage={2} totalPages={3} prevClick={prevClickMock} />
+      )
+
+      fireEvent.click(getByTestId('prevBtn'))
+
+      expect(prevClickMock).toHaveBeenCalled()
+    })
+  })
+
+  describe('nextUrl prop', () => {
+    it('should apply href property to right button', () => {
+      const { container, getByTestId } = render(
+        <Pagination
+          currentPage={2}
+          totalPages={3}
+          nextUrl="https://www.test.com/"
+        />
+      )
+      // snapshot with url
+      expect(container).toMatchSnapshot()
+      // href
+      expect(getByTestId('nextBtn').href).toBe('https://www.test.com/')
+    })
+  })
+
+  describe('prevUrl prop', () => {
+    it('should apply href property to left button', () => {
+      const { container, getByTestId } = render(
+        <Pagination
+          currentPage={2}
+          totalPages={3}
+          prevUrl="https://www.test.com/"
+        />
+      )
+      // snapshot with url
+      expect(container).toMatchSnapshot()
+      // href
+      expect(getByTestId('prevBtn').href).toBe('https://www.test.com/')
+    })
+  })
+})

--- a/src/components/Pagination/Pagination.test.js
+++ b/src/components/Pagination/Pagination.test.js
@@ -39,7 +39,7 @@ describe('<Pagination />', () => {
 
       fireEvent.click(getByTestId('nextBtn'))
 
-      expect(nextClickMock).toHaveBeenCalled()
+      expect(nextClickMock).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -52,7 +52,7 @@ describe('<Pagination />', () => {
 
       fireEvent.click(getByTestId('prevBtn'))
 
-      expect(prevClickMock).toHaveBeenCalled()
+      expect(prevClickMock).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/components/Pagination/__snapshots__/Pagination.test.js.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.js.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Pagination /> Snapshots should match snapshot 1`] = `
+<div>
+  <nav
+    class="styledCol__ColWrapper-sc-1mivnjm-0 gaLJSE StyledPagination-hmwnoe-0 cmeGul"
+  >
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="prevBtn"
+      type="button"
+    >
+      &lt; Prev
+    </button>
+    <p
+      class="StyledParagraph-sc-1toaej-0 gpltyO StyledPagination__PaginationCounter-hmwnoe-2 dMIRzi"
+    >
+      Page 2 of 3
+    </p>
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="nextBtn"
+      type="button"
+    >
+      Next &gt;
+    </button>
+  </nav>
+</div>
+`;
+
+exports[`<Pagination /> Snapshots should match snapshot in Welsh 1`] = `
+<div>
+  <nav
+    class="styledCol__ColWrapper-sc-1mivnjm-0 gaLJSE StyledPagination-hmwnoe-0 cmeGul"
+  >
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="prevBtn"
+      type="button"
+    >
+      &lt; Flaenorol
+    </button>
+    <p
+      class="StyledParagraph-sc-1toaej-0 gpltyO StyledPagination__PaginationCounter-hmwnoe-2 dMIRzi"
+    >
+      Tudalen 2 o 3
+    </p>
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="nextBtn"
+      type="button"
+    >
+      Nesaf &gt;
+    </button>
+  </nav>
+</div>
+`;
+
+exports[`<Pagination /> Snapshots should match snapshot in first page 1`] = `
+<div>
+  <nav
+    class="styledCol__ColWrapper-sc-1mivnjm-0 gaLJSE StyledPagination-hmwnoe-0 cmeGul"
+  >
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1 cOvXO"
+      data-testid="prevBtn"
+      type="button"
+    >
+      &lt; Prev
+    </button>
+    <p
+      class="StyledParagraph-sc-1toaej-0 gpltyO StyledPagination__PaginationCounter-hmwnoe-2 dMIRzi"
+    >
+      Page 1 of 2
+    </p>
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="nextBtn"
+      type="button"
+    >
+      Next &gt;
+    </button>
+  </nav>
+</div>
+`;
+
+exports[`<Pagination /> Snapshots should match snapshot in last page 1`] = `
+<div>
+  <nav
+    class="styledCol__ColWrapper-sc-1mivnjm-0 gaLJSE StyledPagination-hmwnoe-0 cmeGul"
+  >
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="prevBtn"
+      type="button"
+    >
+      &lt; Prev
+    </button>
+    <p
+      class="StyledParagraph-sc-1toaej-0 gpltyO StyledPagination__PaginationCounter-hmwnoe-2 dMIRzi"
+    >
+      Page 3 of 3
+    </p>
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1 cOvXO"
+      data-testid="nextBtn"
+      type="button"
+    >
+      Next &gt;
+    </button>
+  </nav>
+</div>
+`;
+
+exports[`<Pagination /> nextUrl prop should apply href property to right button 1`] = `
+<div>
+  <nav
+    class="styledCol__ColWrapper-sc-1mivnjm-0 gaLJSE StyledPagination-hmwnoe-0 cmeGul"
+  >
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="prevBtn"
+      type="button"
+    >
+      &lt; Prev
+    </button>
+    <p
+      class="StyledParagraph-sc-1toaej-0 gpltyO StyledPagination__PaginationCounter-hmwnoe-2 dMIRzi"
+    >
+      Page 2 of 3
+    </p>
+    <a
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="nextBtn"
+      href="https://www.test.com/"
+    >
+      Next &gt;
+    </a>
+  </nav>
+</div>
+`;
+
+exports[`<Pagination /> prevUrl prop should apply href property to left button 1`] = `
+<div>
+  <nav
+    class="styledCol__ColWrapper-sc-1mivnjm-0 gaLJSE StyledPagination-hmwnoe-0 cmeGul"
+  >
+    <a
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="prevBtn"
+      href="https://www.test.com/"
+    >
+      &lt; Prev
+    </a>
+    <p
+      class="StyledParagraph-sc-1toaej-0 gpltyO StyledPagination__PaginationCounter-hmwnoe-2 dMIRzi"
+    >
+      Page 2 of 3
+    </p>
+    <button
+      class="buttonStyles__ButtonWrapper-sc-1c1ve7f-0 jEdQwJ StyledPagination__PaginationButton-hmwnoe-1"
+      data-testid="nextBtn"
+      type="button"
+    >
+      Next &gt;
+    </button>
+  </nav>
+</div>
+`;

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -38,6 +38,7 @@ const Pagination = ({
         href={prevUrl}
         onClick={prevClick}
         noShow={currentPage === 1}
+        data-testid="prevBtn"
       />
       <PaginationCounter>
         {`${i18n.page} ${currentPage} ${i18n.of} ${totalPages}`}
@@ -48,6 +49,7 @@ const Pagination = ({
         href={nextUrl}
         onClick={nextClick}
         noShow={currentPage === totalPages}
+        data-testid="nextBtn"
       />
     </StyledPagination>
   )

--- a/src/components/Paragraph/Paragraph.test.js
+++ b/src/components/Paragraph/Paragraph.test.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render } from '../../utils/testing'
+import { Paragraph } from '../Paragraph'
+
+describe('<Paragraph />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot with children element', () => {
+      const { container } = render(<Paragraph>example child</Paragraph>)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot with italic, width and margin props', () => {
+      const { container } = render(
+        <Paragraph italic width="75%" margin={{ bottom: '50px' }}>
+          example child
+        </Paragraph>
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot with underline, weight and textAlign props', () => {
+      const { container } = render(
+        <Paragraph underline weight="700" textAlign="justify">
+          example child
+        </Paragraph>
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot with color and strike props', () => {
+      const { container } = render(
+        <Paragraph color="salmon" strike>
+          example child
+        </Paragraph>
+      )
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/Paragraph/__snapshots__/Paragraph.test.js.snap
+++ b/src/components/Paragraph/__snapshots__/Paragraph.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Paragraph /> Snapshots should match snapshot with children element 1`] = `
+<div>
+  <p
+    class="StyledParagraph-sc-1toaej-0 gpltyO"
+  >
+    example child
+  </p>
+</div>
+`;
+
+exports[`<Paragraph /> Snapshots should match snapshot with color and strike props 1`] = `
+<div>
+  <p
+    class="StyledParagraph-sc-1toaej-0 fKkfYQ"
+  >
+    example child
+  </p>
+</div>
+`;
+
+exports[`<Paragraph /> Snapshots should match snapshot with italic, width and margin props 1`] = `
+<div>
+  <p
+    class="StyledParagraph-sc-1toaej-0 gZXJRU"
+  >
+    example child
+  </p>
+</div>
+`;
+
+exports[`<Paragraph /> Snapshots should match snapshot with underline, weight and textAlign props 1`] = `
+<div>
+  <p
+    class="StyledParagraph-sc-1toaej-0 dtXQbJ"
+  >
+    example child
+  </p>
+</div>
+`;

--- a/src/components/Radio/Radio.test.js
+++ b/src/components/Radio/Radio.test.js
@@ -37,7 +37,7 @@ describe('<Radio />', () => {
 
       fireEvent.click(getByTestId('radio'))
 
-      expect(onChangeMock).toHaveBeenCalled()
+      expect(onChangeMock).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/Radio/Radio.test.js
+++ b/src/components/Radio/Radio.test.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { render, fireEvent } from '../../utils/testing'
+import { Radio } from '../Radio'
+
+describe('<Radio />', () => {
+  describe('Snapshots', () => {
+    it('should match snapshot without props', () => {
+      const { container } = render(<Radio />)
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot with disabled prop', () => {
+      const { container } = render(<Radio disabled />)
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot with checked prop', () => {
+      const { container } = render(<Radio checked onChange={e => {}} />)
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match snapshot with checked and disabled prop', () => {
+      const { container } = render(
+        <Radio checked disabled onChange={e => {}} />
+      )
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('onChange prop', () => {
+    it('should call onChange callback when RadioButton is changed', () => {
+      const onChangeMock = jest.fn()
+      const { getByTestId } = render(
+        <Radio onChange={onChangeMock} data-testid="radio">
+          Radio
+        </Radio>
+      )
+
+      fireEvent.click(getByTestId('radio'))
+
+      expect(onChangeMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/Radio/__snapshots__/Radio.test.js.snap
+++ b/src/components/Radio/__snapshots__/Radio.test.js.snap
@@ -3,15 +3,18 @@
 exports[`<Radio /> Snapshots should match snapshot with checked and disabled prop 1`] = `
 <div>
   <label
-    class="StyledRadio__Label-sc-1awvsvp-0 fOeuR"
+    class="StyledRadio__Label-sc-1awvsvp-0 fDTlvj"
     disabled=""
   >
     <input
       checked=""
-      class="StyledRadio__Field-sc-1awvsvp-1 atQEc"
+      class="StyledRadio__Field-sc-1awvsvp-1 bBSLqf"
       disabled=""
       type="radio"
       value=""
+    />
+    <p
+      class="StyledParagraph-sc-1toaej-0 ZKQVH"
     />
   </label>
 </div>
@@ -20,13 +23,16 @@ exports[`<Radio /> Snapshots should match snapshot with checked and disabled pro
 exports[`<Radio /> Snapshots should match snapshot with checked prop 1`] = `
 <div>
   <label
-    class="StyledRadio__Label-sc-1awvsvp-0 jyUodG"
+    class="StyledRadio__Label-sc-1awvsvp-0 fYWYHJ"
   >
     <input
       checked=""
-      class="StyledRadio__Field-sc-1awvsvp-1 atQEc"
+      class="StyledRadio__Field-sc-1awvsvp-1 bBSLqf"
       type="radio"
       value=""
+    />
+    <p
+      class="StyledParagraph-sc-1toaej-0 ZKQVH"
     />
   </label>
 </div>
@@ -35,14 +41,17 @@ exports[`<Radio /> Snapshots should match snapshot with checked prop 1`] = `
 exports[`<Radio /> Snapshots should match snapshot with disabled prop 1`] = `
 <div>
   <label
-    class="StyledRadio__Label-sc-1awvsvp-0 fOeuR"
+    class="StyledRadio__Label-sc-1awvsvp-0 fDTlvj"
     disabled=""
   >
     <input
-      class="StyledRadio__Field-sc-1awvsvp-1 atQEc"
+      class="StyledRadio__Field-sc-1awvsvp-1 bBSLqf"
       disabled=""
       type="radio"
       value=""
+    />
+    <p
+      class="StyledParagraph-sc-1toaej-0 ZKQVH"
     />
   </label>
 </div>
@@ -51,12 +60,15 @@ exports[`<Radio /> Snapshots should match snapshot with disabled prop 1`] = `
 exports[`<Radio /> Snapshots should match snapshot without props 1`] = `
 <div>
   <label
-    class="StyledRadio__Label-sc-1awvsvp-0 jyUodG"
+    class="StyledRadio__Label-sc-1awvsvp-0 fYWYHJ"
   >
     <input
-      class="StyledRadio__Field-sc-1awvsvp-1 atQEc"
+      class="StyledRadio__Field-sc-1awvsvp-1 bBSLqf"
       type="radio"
       value=""
+    />
+    <p
+      class="StyledParagraph-sc-1toaej-0 ZKQVH"
     />
   </label>
 </div>

--- a/src/components/Radio/__snapshots__/Radio.test.js.snap
+++ b/src/components/Radio/__snapshots__/Radio.test.js.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Radio /> Snapshots should match snapshot with checked and disabled prop 1`] = `
+<div>
+  <label
+    class="StyledRadio__Label-sc-1awvsvp-0 fOeuR"
+    disabled=""
+  >
+    <input
+      checked=""
+      class="StyledRadio__Field-sc-1awvsvp-1 atQEc"
+      disabled=""
+      type="radio"
+      value=""
+    />
+  </label>
+</div>
+`;
+
+exports[`<Radio /> Snapshots should match snapshot with checked prop 1`] = `
+<div>
+  <label
+    class="StyledRadio__Label-sc-1awvsvp-0 jyUodG"
+  >
+    <input
+      checked=""
+      class="StyledRadio__Field-sc-1awvsvp-1 atQEc"
+      type="radio"
+      value=""
+    />
+  </label>
+</div>
+`;
+
+exports[`<Radio /> Snapshots should match snapshot with disabled prop 1`] = `
+<div>
+  <label
+    class="StyledRadio__Label-sc-1awvsvp-0 fOeuR"
+    disabled=""
+  >
+    <input
+      class="StyledRadio__Field-sc-1awvsvp-1 atQEc"
+      disabled=""
+      type="radio"
+      value=""
+    />
+  </label>
+</div>
+`;
+
+exports[`<Radio /> Snapshots should match snapshot without props 1`] = `
+<div>
+  <label
+    class="StyledRadio__Label-sc-1awvsvp-0 jyUodG"
+  >
+    <input
+      class="StyledRadio__Field-sc-1awvsvp-1 atQEc"
+      type="radio"
+      value=""
+    />
+  </label>
+</div>
+`;

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent, screen } from '../../utils/testing'
+import { render, fireEvent } from '../../utils/testing'
 import { Select } from '../Select'
 
 describe('<Select />', () => {

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import { render, fireEvent, screen } from '../../utils/testing'
+import { Select } from '../Select'
+
+describe('<Select />', () => {
+  const options = ['option1', 'option2', 'option3']
+
+  describe('Snapshots', () => {
+    it('should match snapshot with options, id and label', () => {
+      const { container } = render(
+        <Select id="test" label="test label" options={['option 1']} />
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot disabled', () => {
+      const { container } = render(
+        <Select
+          disabled
+          id="disabled"
+          label="test disabled"
+          options={['option 1']}
+        />
+      )
+      expect(container).toMatchSnapshot()
+    })
+    it('should match snapshot with multiple options', () => {
+      const { container } = render(
+        <Select id="options" label="test options" options={options} />
+      )
+      expect(container).toMatchSnapshot()
+    })
+  })
+
+  describe('options prop', () => {
+    it('should display correct number of options', () => {
+      const { container } = render(<Select id="options" options={options} />)
+      const dropDownOptions = container.querySelectorAll('option')
+
+      expect(dropDownOptions.length).toBe(3)
+    })
+
+    it('should display correct option text', () => {
+      const { container } = render(<Select id="options" options={options} />)
+      const dropDownOptions = container.querySelectorAll('option')
+      const [opt1, opt2, opt3] = Array.from(dropDownOptions)
+
+      expect(opt1.textContent).toBe(options[0])
+      expect(opt2.textContent).toBe(options[1])
+      expect(opt3.textContent).toBe(options[2])
+    })
+  })
+
+  describe('onChange prop', () => {
+    it('should call onChange function when option is changed', () => {
+      const onChangeMock = jest.fn()
+      const { getByTestId } = render(
+        <Select
+          data-testid="select"
+          id="change"
+          onChange={onChangeMock}
+          options={options}
+        />
+      )
+
+      fireEvent.change(getByTestId('select'), {
+        target: { value: 'option2' },
+      })
+
+      expect(onChangeMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/Select/Select.test.js
+++ b/src/components/Select/Select.test.js
@@ -66,7 +66,7 @@ describe('<Select />', () => {
         target: { value: 'option2' },
       })
 
-      expect(onChangeMock).toHaveBeenCalled()
+      expect(onChangeMock).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/src/components/Select/__snapshots__/Select.test.js.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Select /> Snapshots should match snapshot disabled 1`] = `
+<div>
+  <label
+    class="StyledSelect__Label-sc-17qnzyp-0 kOMahN"
+    disabled=""
+    for="disabled"
+  >
+    test disabled
+  </label>
+  <select
+    class="StyledSelect__Field-sc-17qnzyp-1 hGHanr"
+    disabled=""
+    id="disabled"
+  >
+    <option
+      value="option 1"
+    >
+      option 1
+    </option>
+  </select>
+</div>
+`;
+
+exports[`<Select /> Snapshots should match snapshot with multiple options 1`] = `
+<div>
+  <label
+    class="StyledSelect__Label-sc-17qnzyp-0 feVND"
+    for="options"
+  >
+    test options
+  </label>
+  <select
+    class="StyledSelect__Field-sc-17qnzyp-1 hGHanr"
+    id="options"
+  >
+    <option
+      value="option1"
+    >
+      option1
+    </option>
+    <option
+      value="option2"
+    >
+      option2
+    </option>
+    <option
+      value="option3"
+    >
+      option3
+    </option>
+  </select>
+</div>
+`;
+
+exports[`<Select /> Snapshots should match snapshot with options, id and label 1`] = `
+<div>
+  <label
+    class="StyledSelect__Label-sc-17qnzyp-0 feVND"
+    for="test"
+  >
+    test label
+  </label>
+  <select
+    class="StyledSelect__Field-sc-17qnzyp-1 hGHanr"
+    id="test"
+  >
+    <option
+      value="option 1"
+    >
+      option 1
+    </option>
+  </select>
+</div>
+`;

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -17,7 +17,7 @@ const Select = ({
 }) => (
   <>
     {label && (
-      <Label disabled={disabled} hide={hideLabel} for={id}>
+      <Label disabled={disabled} hide={hideLabel} htmlFor={id}>
         {label}
       </Label>
     )}
@@ -55,7 +55,7 @@ Select.propTypes = {
   /** Sets the width of the select element. */
   width: PropTypes.string,
   /** Options for the select element. */
-  options: PropTypes.array,
+  options: PropTypes.array.isRequired,
   /** On change trigger function event. */
   onChange: PropTypes.func,
   ...genericPropTypes,

--- a/src/components/Tooltip/Tooltip.test.js
+++ b/src/components/Tooltip/Tooltip.test.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, fireEvent, act } from '../../utils/testing'
+import { Tooltip } from '../Tooltip'
+
+describe('<Tooltip />', () => {
+  describe('Snapshot', () => {
+    it('should match click snapshot', () => {
+      const { container } = render(<Tooltip text="Tooltip text" />)
+      // tooltip closed
+      expect(container).toMatchSnapshot()
+      // click on icon
+      act(() => {
+        fireEvent.click(container.firstChild)
+      })
+      // tooltip opened
+      expect(container).toMatchSnapshot()
+    })
+
+    it('should match hover snapshot with children', () => {
+      const { container } = render(
+        <Tooltip hover text="Tooltip text">
+          <span>hover</span>
+        </Tooltip>
+      )
+      // tooltip closed
+      expect(container).toMatchSnapshot()
+      // hover
+      act(() => {
+        fireEvent.mouseEnter(container)
+      })
+      // tooltip opened
+      expect(container).toMatchSnapshot()
+    })
+  })
+})

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Tooltip /> Snapshot should match hover snapshot 1`] = `
+<div>
+  <span
+    class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
+  >
+    <span>
+      <span>
+        hover
+      </span>
+    </span>
+  </span>
+</div>
+`;
+
+exports[`<Tooltip /> Snapshot should match hover snapshot 2`] = `
+<div>
+  <span
+    class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
+  >
+    <span>
+      <span>
+        hover
+      </span>
+    </span>
+  </span>
+</div>
+`;
+
+exports[`<Tooltip /> Snapshot should match snapshot 1`] = `
+<div>
+  <span
+    class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
+  >
+    <a
+      class="StyledParagraph-sc-1toaej-0 drRbGa StyledAnchor-sc-1qj1ci5-0 fNhjgf StyledTooltip__Icon-sc-1uvk9zg-2 kLqhMp"
+    >
+      i
+    </a>
+  </span>
+</div>
+`;
+
+exports[`<Tooltip /> Snapshot should match snapshot 2`] = `
+<div>
+  <span
+    class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
+  >
+    <a
+      class="StyledParagraph-sc-1toaej-0 drRbGa StyledAnchor-sc-1qj1ci5-0 fNhjgf StyledTooltip__Icon-sc-1uvk9zg-2 kLqhMp"
+    >
+      i
+    </a>
+  </span>
+</div>
+`;

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -1,34 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Tooltip /> Snapshot should match hover snapshot 1`] = `
-<div>
-  <span
-    class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
-  >
-    <span>
-      <span>
-        hover
-      </span>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`<Tooltip /> Snapshot should match hover snapshot 2`] = `
-<div>
-  <span
-    class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
-  >
-    <span>
-      <span>
-        hover
-      </span>
-    </span>
-  </span>
-</div>
-`;
-
-exports[`<Tooltip /> Snapshot should match snapshot 1`] = `
+exports[`<Tooltip /> Snapshot should match click snapshot 1`] = `
 <div>
   <span
     class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
@@ -42,7 +14,7 @@ exports[`<Tooltip /> Snapshot should match snapshot 1`] = `
 </div>
 `;
 
-exports[`<Tooltip /> Snapshot should match snapshot 2`] = `
+exports[`<Tooltip /> Snapshot should match click snapshot 2`] = `
 <div>
   <span
     class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
@@ -52,6 +24,34 @@ exports[`<Tooltip /> Snapshot should match snapshot 2`] = `
     >
       i
     </a>
+  </span>
+</div>
+`;
+
+exports[`<Tooltip /> Snapshot should match hover snapshot with children 1`] = `
+<div>
+  <span
+    class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
+  >
+    <span>
+      <span>
+        hover
+      </span>
+    </span>
+  </span>
+</div>
+`;
+
+exports[`<Tooltip /> Snapshot should match hover snapshot with children 2`] = `
+<div>
+  <span
+    class="StyledTooltip-sc-1uvk9zg-0 dWzGPd"
+  >
+    <span>
+      <span>
+        hover
+      </span>
+    </span>
   </span>
 </div>
 `;

--- a/src/utils/testing.js
+++ b/src/utils/testing.js
@@ -1,0 +1,19 @@
+import { render, act } from '@testing-library/react'
+import GlobalTheme from '../components/ThemeProvider'
+
+const customRender = (ui, options) =>
+  render(ui, { wrapper: GlobalTheme, ...options })
+
+const waitRender = async (ui, options) => {
+  const { container, ...rest } = customRender(ui, options)
+
+  await act(async () => {
+    await Promise.resolve(container)
+  })
+
+  return { container, ...rest }
+}
+
+export * from '@testing-library/react'
+
+export { customRender as render, waitRender }


### PR DESCRIPTION
[TP11737](https://maps.tpondemand.com/entity/11737-implement-component-tests)

This PR aims to implement tests for most of the components found in the library. It has a total of 14 test suites, 59 tests with 46 snapshots. These tests can be improved in the future but for now I believe this provides a good base to start with.

Tests for most components can be found except for `Grid`, `CompanyCard`, `Heading` and `Accordion` since I believe that to develop tests for these components would deserve their own TP ticket as they can be more complex.

I would advice to review this PR on a commit by commit basis since this is quite large as it also includes the new snapshots for each of the components.

Tests can be done using `npm test`.